### PR TITLE
Python formatting

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 from app import app, db
 from app.models import User, Upload
 
+
 @app.shell_context_processor
 def make_shell_context():
     return {'db': db, 'User': User, 'Upload': Upload}

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -58,7 +58,7 @@ def set_admin_pw(password):
 
     user = db.session.merge(user)
 
-    if (user.check_password(password)):
+    if user.check_password(password):
         db.session.commit()
         print('Password not changed')
         return

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,13 +1,15 @@
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+
+import click
 from flask import Flask
-from config import Config
-from flask_sqlalchemy import SQLAlchemy
-from flask_migrate import Migrate
 from flask_login import LoginManager
 from flask_mail import Mail
-import logging
-from logging.handlers import RotatingFileHandler
-import os
-import click
+from flask_migrate import Migrate
+from flask_sqlalchemy import SQLAlchemy
+
+from config import Config
 
 app = Flask(__name__)
 app.config.from_object(Config)
@@ -19,6 +21,7 @@ login.login_view = 'login'
 mail = Mail(app)
 
 from .data.scan_store import ScanStore
+
 scanStore = ScanStore(db)
 
 if not app.debug:
@@ -37,23 +40,25 @@ if not app.debug:
 from app import models, routes, errors
 from .routes import taskQueue
 
+
 @app.shell_context_processor
 def make_shell_context():
     return {'db': db, 'User': models.User, 'Scan': models.Scan}
+
 
 @app.cli.command()
 @click.argument('password')
 def set_admin_pw(password):
     user = models.User(
-        id = 1,
-        name = 'Administrator',
-        email = 'admin',
-        role = 'ADMIN'
+        id=1,
+        name='Administrator',
+        email='admin',
+        role='ADMIN'
     )
 
     user = db.session.merge(user)
 
-    if(user.checkPassword(password)):
+    if (user.checkPassword(password)):
         db.session.commit()
         print('Password not changed')
         return
@@ -63,20 +68,25 @@ def set_admin_pw(password):
 
     print('Password changed')
 
+
 from .tasks.server import TaskExecutor
 
 taskExecutor = TaskExecutor(models.Queue, scanStore)
+
 
 @app.cli.command()
 @click.argument('scan_slug')
 def create_ctm(scan_slug):
     taskQueue.create_ctm(scan_slug)
 
+
 @app.cli.command()
 def task_runner():
     taskExecutor.run()
 
+
 import sys
+
 
 @app.cli.command()
 def task():

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -22,7 +22,7 @@ mail = Mail(app)
 
 from .data.scan_store import ScanStore
 
-scanStore = ScanStore(db)
+scan_store = ScanStore(db)
 
 if not app.debug:
     if not os.path.exists('logs'):
@@ -38,7 +38,7 @@ if not app.debug:
     app.logger.info('Phenome10k startup')
 
 from app import models, routes, errors
-from .routes import taskQueue
+from .routes import task_queue
 
 
 @app.shell_context_processor
@@ -71,18 +71,18 @@ def set_admin_pw(password):
 
 from .tasks.server import TaskExecutor
 
-taskExecutor = TaskExecutor(models.Queue, scanStore)
+task_executor = TaskExecutor(models.Queue, scan_store)
 
 
 @app.cli.command()
 @click.argument('scan_slug')
 def create_ctm(scan_slug):
-    taskQueue.create_ctm(scan_slug)
+    task_queue.create_ctm(scan_slug)
 
 
 @app.cli.command()
 def task_runner():
-    taskExecutor.run()
+    task_executor.run()
 
 
 import sys
@@ -90,7 +90,7 @@ import sys
 
 @app.cli.command()
 def task():
-    res = taskExecutor.next()
+    res = task_executor.next()
     if res:
         print('task success')
     else:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import sys
 from logging.handlers import RotatingFileHandler
 
 import click
@@ -37,7 +38,7 @@ if not app.debug:
     app.logger.setLevel(logging.INFO)
     app.logger.info('Phenome10k startup')
 
-from app import models, routes, errors
+from . import models, routes, errors
 from .routes import task_queue
 
 
@@ -83,9 +84,6 @@ def create_ctm(scan_slug):
 @app.cli.command()
 def task_runner():
     task_executor.run()
-
-
-import sys
 
 
 @app.cli.command()

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -58,12 +58,12 @@ def set_admin_pw(password):
 
     user = db.session.merge(user)
 
-    if (user.checkPassword(password)):
+    if (user.check_password(password)):
         db.session.commit()
         print('Password not changed')
         return
 
-    user.setPassword(password)
+    user.set_password(password)
     db.session.commit()
 
     print('Password changed')

--- a/app/data/ctmconv.py
+++ b/app/data/ctmconv.py
@@ -1,7 +1,8 @@
 import trimesh
-from openctm import CTM, import_mesh, export_mesh
+from openctm import CTM, export_mesh
+
 
 def ctmconv(source, dest):
-	mesh = trimesh.load(source)
-	ctm = CTM(mesh.vertices, mesh.faces, mesh.face_normals)
-	export_mesh(ctm, dest)
+    mesh = trimesh.load(source)
+    ctm = CTM(mesh.vertices, mesh.faces, mesh.face_normals)
+    export_mesh(ctm, dest)

--- a/app/data/scan_store.py
+++ b/app/data/scan_store.py
@@ -76,7 +76,7 @@ class ScanStore:
     def new(self, author_uri):
         # Create instance of scan
         author = models.User.query.filter_by(email=author_uri).first()
-        if author == None:
+        if author is None:
             raise NoAuthor('No author for ' + author_uri)
 
         scan = models.Scan(

--- a/app/data/scan_store.py
+++ b/app/data/scan_store.py
@@ -107,9 +107,9 @@ class ScanStore:
         scan.description = data.get('description')
         scan.publications = data.get('publications')
 
-        scan.tags = data.get('geologic_age') \
-                    + data.get('ontogenic_age') \
-                    + data.get('elements')
+        scan.tags = (data.get('geologic_age')
+                     + data.get('ontogenic_age')
+                     + data.get('elements'))
 
         gbif_id = data.get('gbif_id')
 

--- a/app/data/scan_store.py
+++ b/app/data/scan_store.py
@@ -68,7 +68,8 @@ class ScanStore:
 
         return zip
 
-    def create(self, file, author_uri, data, attachments=[]):
+    def create(self, file, author_uri, data, attachments=None):
+        attachments = attachments or []
         scan = self.new(author_uri)
 
         return self.update(scan, file, data, attachments)
@@ -87,7 +88,8 @@ class ScanStore:
 
         return scan
 
-    def update(self, scan, file, data, attachments=[]):
+    def update(self, scan, file, data, attachments=None):
+        attachments = attachments or []
         author_id = scan.author_id
         # Save upload to temporary file
         if file:

--- a/app/data/scan_store.py
+++ b/app/data/scan_store.py
@@ -54,12 +54,12 @@ class ScanStore:
         zip_file.mime_type = 'application/zip'
 
         filename, file_ext = os.path.splitext(file.filename)
-        with tempfile.NamedTemporaryFile(suffix=file_ext) as uploadFile:
+        with tempfile.NamedTemporaryFile(suffix=file_ext) as upload_file:
             # app.logger.warn('save upload to temp')
-            file.save(uploadFile.name)
+            file.save(upload_file.name)
             with ZipFile(zip_file.get_absolute_path(), 'w', ZIP_DEFLATED) as zf:
                 # app.logger.warn('write temp file to zip')
-                zf.write(uploadFile.name, file.filename)
+                zf.write(upload_file.name, file.filename)
 
         # app.logger.warn('set zip size')
         zip_file.size = os.stat(zip_file.get_absolute_path()).st_size
@@ -193,19 +193,19 @@ class ScanStore:
 
             filename, file_ext = os.path.splitext(upload_file_name)
 
-            with tempfile.NamedTemporaryFile(suffix=file_ext) as uploadFile:
-                uploadFile.write(upload_file_data)
+            with tempfile.NamedTemporaryFile(suffix=file_ext) as upload_file:
+                upload_file.write(upload_file_data)
 
                 # Convert to bin if ascii
-                uploadFile.seek(0)
-                if uploadFile.read(5) == b'solid':
-                    Mesh.from_file(uploadFile.name).save(uploadFile.name)
+                upload_file.seek(0)
+                if upload_file.read(5) == b'solid':
+                    Mesh.from_file(upload_file.name).save(upload_file.name)
 
                 # Convert to ctm in uploads storage
                 ctm_file = models.File.from_name(filename + '.ctm', owner_id=scan.author_id)
                 ctm_file.mime_type = 'application/octet-stream'
 
-                ctmconv(uploadFile.name, ctm_file.get_absolute_path())
+                ctmconv(upload_file.name, ctm_file.get_absolute_path())
 
                 ctm_file.size = os.stat(ctm_file.get_absolute_path()).st_size
 

--- a/app/data/scan_store.py
+++ b/app/data/scan_store.py
@@ -42,7 +42,7 @@ class ScanStore:
             # app.logger.warn('zip file, validate contents')
             print(file.stream)
             zip_file = ZipFile(file.stream, 'r', ZIP_DEFLATED)
-            if (len(zip_file.infolist()) != 1):
+            if len(zip_file.infolist()) != 1:
                 # app.logger.error('wrong number of files in zip')
                 raise AmbiguousZip('ZIP uploads must contain exactly one file')
             # app.logger.warn('valid zip')
@@ -141,7 +141,7 @@ class ScanStore:
 
             file_model = models.File.from_binary(filename, file.stream, owner_id=author_id)
 
-            if (file_model.mime_type != 'image/png'):
+            if file_model.mime_type != 'image/png':
                 raise InvalidAttachment('Stills must be png files')
             else:
                 file.save(file_model.get_absolute_path())
@@ -165,7 +165,7 @@ class ScanStore:
         if not scan.attachments:
             errors.append('A still is required')
 
-        if (errors):
+        if errors:
             raise Unpublishable('; '.join(errors))
 
         scan.published = True

--- a/app/data/scan_store.py
+++ b/app/data/scan_store.py
@@ -5,9 +5,9 @@ from zipfile import ZipFile, ZIP_DEFLATED
 from stl.mesh import Mesh
 from werkzeug.utils import secure_filename
 
-from .ctmconv import ctmconv
-from .slugs import generate_slug
-from .. import models
+from app.data.ctmconv import ctmconv
+from app.data.slugs import generate_slug
+from app import models
 
 
 class ScanException(Exception):

--- a/app/data/scan_store.py
+++ b/app/data/scan_store.py
@@ -1,208 +1,212 @@
-from .. import models
-from .slugs import generate_slug
 import os
 import tempfile
 from zipfile import ZipFile, ZIP_DEFLATED
-from werkzeug.utils import secure_filename
+
 from stl.mesh import Mesh
-import subprocess
+from werkzeug.utils import secure_filename
+
 from .ctmconv import ctmconv
+from .slugs import generate_slug
+from .. import models
+
 
 class ScanException(Exception):
-	pass
+    pass
+
 
 class AmbiguousZip(ScanException):
-	pass
+    pass
+
 
 class NoAuthor(ScanException):
-	pass
+    pass
+
 
 class InvalidAttachment(ScanException):
-	pass
+    pass
+
 
 class Unpublishable(ScanException):
-	pass
+    pass
+
 
 class ScanStore:
-	def __init__(self, db):
-		self.db = db
-		pass
+    def __init__(self, db):
+        self.db = db
+        pass
 
-	def zip_upload(self, file, owner_id):
-		""" Save the uploaded file as a zip file """
-		# Allow uploading zip file.
-		if file.filename.endswith('.zip'):
-			# app.logger.warn('zip file, validate contents')
-			print(file.stream)
-			zipFile = ZipFile(file.stream, 'r', ZIP_DEFLATED)
-			if(len(zipFile.infolist()) != 1):
-				# app.logger.error('wrong number of files in zip')
-				raise AmbiguousZip('ZIP uploads must contain exactly one file')
-			# app.logger.warn('valid zip')
-			return models.File.fromUpload(file, models.File.MODELS_DIR, owner_id=owner_id)
+    def zip_upload(self, file, owner_id):
+        """ Save the uploaded file as a zip file """
+        # Allow uploading zip file.
+        if file.filename.endswith('.zip'):
+            # app.logger.warn('zip file, validate contents')
+            print(file.stream)
+            zipFile = ZipFile(file.stream, 'r', ZIP_DEFLATED)
+            if (len(zipFile.infolist()) != 1):
+                # app.logger.error('wrong number of files in zip')
+                raise AmbiguousZip('ZIP uploads must contain exactly one file')
+            # app.logger.warn('valid zip')
+            return models.File.fromUpload(file, models.File.MODELS_DIR, owner_id=owner_id)
 
-		# Zip source file & save to large file storage
-		# app.logger.warn('create empty zip')
-		zip = models.File.fromName(file.filename + '.zip', models.File.MODELS_DIR, owner_id=owner_id)
-		zip.mime_type = 'application/zip'
+        # Zip source file & save to large file storage
+        # app.logger.warn('create empty zip')
+        zip = models.File.fromName(file.filename + '.zip', models.File.MODELS_DIR, owner_id=owner_id)
+        zip.mime_type = 'application/zip'
 
-		filename, fileExt = os.path.splitext(file.filename)
-		with tempfile.NamedTemporaryFile(suffix=fileExt) as uploadFile:
-			# app.logger.warn('save upload to temp')
-			file.save(uploadFile.name)
-			with ZipFile(zip.getAbsolutePath(), 'w', ZIP_DEFLATED) as zipFile:
-				# app.logger.warn('write temp file to zip')
-				zipFile.write(uploadFile.name, file.filename)
+        filename, fileExt = os.path.splitext(file.filename)
+        with tempfile.NamedTemporaryFile(suffix=fileExt) as uploadFile:
+            # app.logger.warn('save upload to temp')
+            file.save(uploadFile.name)
+            with ZipFile(zip.getAbsolutePath(), 'w', ZIP_DEFLATED) as zipFile:
+                # app.logger.warn('write temp file to zip')
+                zipFile.write(uploadFile.name, file.filename)
 
-		# app.logger.warn('set zip size')
-		zip.size = os.stat(zip.getAbsolutePath()).st_size
+        # app.logger.warn('set zip size')
+        zip.size = os.stat(zip.getAbsolutePath()).st_size
 
-		# app.logger.warn('generated zip')
+        # app.logger.warn('generated zip')
 
-		return zip
+        return zip
 
-	def create(self, file, author_uri, data, attachments=[]):
-		scan = self.new(author_uri)
+    def create(self, file, author_uri, data, attachments=[]):
+        scan = self.new(author_uri)
 
-		return self.update(scan, file, data, attachments)
+        return self.update(scan, file, data, attachments)
 
-	def new(self, author_uri):
-		# Create instance of scan
-		author = models.User.query.filter_by(email=author_uri).first()
-		if author == None :
-			raise NoAuthor("No author for " + author_uri)
+    def new(self, author_uri):
+        # Create instance of scan
+        author = models.User.query.filter_by(email=author_uri).first()
+        if author == None:
+            raise NoAuthor('No author for ' + author_uri)
 
-		scan = models.Scan(
-			author_id = author.id
-		)
+        scan = models.Scan(
+            author_id=author.id
+        )
 
-		self.db.session.add(scan)
+        self.db.session.add(scan)
 
-		return scan
+        return scan
 
-	def update(self, scan, file, data, attachments=[]):
-		author_id = scan.author_id
-		# Save upload to temporary file
-		if file:
-			zipFile = self.zip_upload(file, author_id)
-			scan.source = zipFile
-			self.db.session.add(zipFile)
+    def update(self, scan, file, data, attachments=[]):
+        author_id = scan.author_id
+        # Save upload to temporary file
+        if file:
+            zipFile = self.zip_upload(file, author_id)
+            scan.source = zipFile
+            self.db.session.add(zipFile)
 
-		scan.scientific_name = 	data.get('scientific_name')
+        scan.scientific_name = data.get('scientific_name')
 
-		if (not scan.url_slug) and scan.scientific_name:
-			scan.url_slug = 	generate_slug(scan.scientific_name)
+        if (not scan.url_slug) and scan.scientific_name:
+            scan.url_slug = generate_slug(scan.scientific_name)
 
-		scan.alt_name = 	data.get('alt_name')
-		scan.specimen_location = 	data.get('specimen_location')
-		scan.specimen_id = 	data.get('specimen_id')
-		scan.specimen_url = 	data.get('specimen_url')
-		scan.description = 	data.get('description')
-		scan.publications = 	data.get('publications')
+        scan.alt_name = data.get('alt_name')
+        scan.specimen_location = data.get('specimen_location')
+        scan.specimen_id = data.get('specimen_id')
+        scan.specimen_url = data.get('specimen_url')
+        scan.description = data.get('description')
+        scan.publications = data.get('publications')
 
-		scan.tags	= data.get('geologic_age')	\
-			+ data.get('ontogenic_age')	\
-			+ data.get('elements')
+        scan.tags = data.get('geologic_age') \
+                    + data.get('ontogenic_age') \
+                    + data.get('elements')
 
-		gbif_id = data.get('gbif_id')
+        gbif_id = data.get('gbif_id')
 
-		if gbif_id and gbif_id != scan.gbif_id:
-			from app.gbif import pull_tags
+        if gbif_id and gbif_id != scan.gbif_id:
+            from app.gbif import pull_tags
 
-			scan.gbif_id = gbif_id
-			tags = pull_tags(gbif_id)
+            scan.gbif_id = gbif_id
+            tags = pull_tags(gbif_id)
 
-			tagIds = [ tag.id for tag in tags ]
-			existingTags = models.Taxonomy.query.filter(models.Taxonomy.id.in_(tagIds)).all()
-			existingTagIds = [ tag.id for tag in existingTags ]
-			scan.taxonomy = existingTags
+            tagIds = [tag.id for tag in tags]
+            existingTags = models.Taxonomy.query.filter(models.Taxonomy.id.in_(tagIds)).all()
+            existingTagIds = [tag.id for tag in existingTags]
+            scan.taxonomy = existingTags
 
-			for tag in tags:
-				if tag.id in existingTagIds:
-					continue
+            for tag in tags:
+                if tag.id in existingTagIds:
+                    continue
 
-				self.db.session.add(tag)
-				scan.taxonomy.append(tag)
+                self.db.session.add(tag)
+                scan.taxonomy.append(tag)
 
-		for file in attachments:
-			# if isinstance(file, Attachment):
-			# 	continue
-			import string
-			import random
-			import magic
+        for file in attachments:
+            # if isinstance(file, Attachment):
+            # 	continue
 
-			# Take the filename as the label and generate a new, safe filename
-			label = file.filename
-			filename = secure_filename(file.filename) + '.png'
+            # Take the filename as the label and generate a new, safe filename
+            label = file.filename
+            filename = secure_filename(file.filename) + '.png'
 
-			fileModel = models.File.fromBinary(filename, file.stream, owner_id=author_id)
+            fileModel = models.File.fromBinary(filename, file.stream, owner_id=author_id)
 
-			if (fileModel.mime_type != 'image/png'):
-				raise InvalidAttachment('Stills must be png files')
-			else:
-				file.save(fileModel.getAbsolutePath())
-				attachment = models.Attachment(
-					name = label,
-					file = fileModel
-				)
-				self.db.session.add(attachment)
-				scan.attachments.append(attachment)
-		self.db.session.commit()
-		return scan.url_slug
+            if (fileModel.mime_type != 'image/png'):
+                raise InvalidAttachment('Stills must be png files')
+            else:
+                file.save(fileModel.getAbsolutePath())
+                attachment = models.Attachment(
+                    name=label,
+                    file=fileModel
+                )
+                self.db.session.add(attachment)
+                scan.attachments.append(attachment)
+        self.db.session.commit()
+        return scan.url_slug
 
-	def publish(self, scan_uri):
-		scan = self.get(scan_uri)
+    def publish(self, scan_uri):
+        scan = self.get(scan_uri)
 
-		errors = []
+        errors = []
 
-		if not scan.source:
-			errors.append('A scan file is required')
+        if not scan.source:
+            errors.append('A scan file is required')
 
-		if not scan.attachments:
-			errors.append('A still is required')
+        if not scan.attachments:
+            errors.append('A still is required')
 
-		if(errors):
-			raise Unpublishable('; '.join(errors))
+        if (errors):
+            raise Unpublishable('; '.join(errors))
 
-		scan.published = True
-		self.db.session.commit()
+        scan.published = True
+        self.db.session.commit()
 
-	def get(self, scan_uri):
-		return models.Scan.findBySlug(scan_uri)
+    def get(self, scan_uri):
+        return models.Scan.findBySlug(scan_uri)
 
-	def create_ctm(self, scan):
-		""" Convert an uploaded model file to a ctm file """
-		if not isinstance(scan, models.Scan):
-			scan = self.get(scan)
+    def create_ctm(self, scan):
+        """ Convert an uploaded model file to a ctm file """
+        if not isinstance(scan, models.Scan):
+            scan = self.get(scan)
 
-		if not scan.source:
-			raise ScanException('Nothing to process; no file has been uploaded')
+        if not scan.source:
+            raise ScanException('Nothing to process; no file has been uploaded')
 
-		zip = scan.source
+        zip = scan.source
 
-		with ZipFile(zip.getAbsolutePath(), 'r', ZIP_DEFLATED) as zipFile:
-			uploadFileName = zipFile.infolist()[0].filename
+        with ZipFile(zip.getAbsolutePath(), 'r', ZIP_DEFLATED) as zipFile:
+            uploadFileName = zipFile.infolist()[0].filename
 
-			uploadFileData = zipFile.read(uploadFileName)
+            uploadFileData = zipFile.read(uploadFileName)
 
-			filename, fileExt = os.path.splitext(uploadFileName)
+            filename, fileExt = os.path.splitext(uploadFileName)
 
-			with tempfile.NamedTemporaryFile(suffix=fileExt) as uploadFile:
-				uploadFile.write(uploadFileData)
+            with tempfile.NamedTemporaryFile(suffix=fileExt) as uploadFile:
+                uploadFile.write(uploadFileData)
 
-				# Convert to bin if ascii
-				uploadFile.seek(0)
-				if uploadFile.read(5) == b'solid':
-					Mesh.from_file(uploadFile.name).save(uploadFile.name)
+                # Convert to bin if ascii
+                uploadFile.seek(0)
+                if uploadFile.read(5) == b'solid':
+                    Mesh.from_file(uploadFile.name).save(uploadFile.name)
 
-				# Convert to ctm in uploads storage
-				ctmFile = models.File.fromName(filename + '.ctm', owner_id=scan.author_id)
-				ctmFile.mime_type = 'application/octet-stream'
+                # Convert to ctm in uploads storage
+                ctmFile = models.File.fromName(filename + '.ctm', owner_id=scan.author_id)
+                ctmFile.mime_type = 'application/octet-stream'
 
-				ctmconv(uploadFile.name, ctmFile.getAbsolutePath())
+                ctmconv(uploadFile.name, ctmFile.getAbsolutePath())
 
-				ctmFile.size = os.stat(ctmFile.getAbsolutePath()).st_size
+                ctmFile.size = os.stat(ctmFile.getAbsolutePath()).st_size
 
-				scan.ctm = ctmFile
-				self.db.session.add(ctmFile)
-				self.db.session.commit()
+                scan.ctm = ctmFile
+                self.db.session.add(ctmFile)
+                self.db.session.commit()

--- a/app/data/slugs.py
+++ b/app/data/slugs.py
@@ -5,8 +5,8 @@ from .. import models
 
 def slug_available(slug):
     """ Returns true if the slug url is available """
-    return (models.Scan.query.filter_by(url_slug=slug).first() == None) \
-           and (models.Publication.query.filter_by(url_slug=slug).first() == None)
+    return (models.Scan.query.filter_by(url_slug=slug).first() is None) and (
+                models.Publication.query.filter_by(url_slug=slug).first() is None)
 
 
 def generate_slug(name):

--- a/app/data/slugs.py
+++ b/app/data/slugs.py
@@ -5,8 +5,8 @@ from .. import models
 
 def slug_available(slug):
     """ Returns true if the slug url is available """
-    return (models.Scan.query.filter_by(url_slug=slug).first() is None) and (
-                models.Publication.query.filter_by(url_slug=slug).first() is None)
+    return ((models.Scan.query.filter_by(url_slug=slug).first() is None)
+            and (models.Publication.query.filter_by(url_slug=slug).first() is None))
 
 
 def generate_slug(name):

--- a/app/data/slugs.py
+++ b/app/data/slugs.py
@@ -1,21 +1,24 @@
-from .. import models
 from werkzeug.utils import secure_filename
 
+from .. import models
+
+
 def slug_available(slug):
-	""" Returns true if the slug url is available """
-	return	(models.Scan.query.filter_by(url_slug = slug).first() == None) \
-		and (models.Publication.query.filter_by(url_slug = slug).first() == None)
+    """ Returns true if the slug url is available """
+    return (models.Scan.query.filter_by(url_slug=slug).first() == None) \
+           and (models.Publication.query.filter_by(url_slug=slug).first() == None)
+
 
 def generate_slug(name):
-	""" Generate a URL slug for a given name """
-	# Slugify the title and check
-	slug = secure_filename(name).lower().replace('_', '-')
-	slug_n = slug
-	n = 1
+    """ Generate a URL slug for a given name """
+    # Slugify the title and check
+    slug = secure_filename(name).lower().replace('_', '-')
+    slug_n = slug
+    n = 1
 
-	# Append an increasing number to the slug until we find an available url
-	while not slug_available(slug_n):
-		n += 1
-		slug_n = slug + '-' + str(n)
+    # Append an increasing number to the slug until we find an available url
+    while not slug_available(slug_n):
+        n += 1
+        slug_n = slug + '-' + str(n)
 
-	return slug_n
+    return slug_n

--- a/app/data/slugs.py
+++ b/app/data/slugs.py
@@ -1,6 +1,6 @@
 from werkzeug.utils import secure_filename
 
-from .. import models
+from app import models
 
 
 def slug_available(slug):

--- a/app/data/test/test_scan_store.py
+++ b/app/data/test/test_scan_store.py
@@ -28,7 +28,7 @@ def database():
             email='admin',
             role='ADMIN'
         )
-        user.setPassword('pass')
+        user.set_password('pass')
         db.session.add(user)
         db.session.commit()
 

--- a/app/data/test/test_scan_store.py
+++ b/app/data/test/test_scan_store.py
@@ -177,7 +177,7 @@ def test_zip_upload(store, zipFile):
 
     scan = store.get(store.create(file, 'admin', data))
 
-    assert scan.source != None
+    assert scan.source is not None
 
 
 def test_empty_zip_upload(store, emptyZip):
@@ -339,4 +339,4 @@ def test_create_ctm(store, horse):
 
     scan = store.get(slug)
 
-    assert scan.ctm != None
+    assert scan.ctm is not None

--- a/app/data/test/test_scan_store.py
+++ b/app/data/test/test_scan_store.py
@@ -293,7 +293,7 @@ def test_publish(store, zipFile, image):
     store.publish(uri)
     scan = store.get(uri)
 
-    assert scan.published == True
+    assert scan.published
 
 
 def test_unpublishable(store):

--- a/app/data/test/test_scan_store.py
+++ b/app/data/test/test_scan_store.py
@@ -81,7 +81,7 @@ def test_scan_store_create(store, image):
     file = ObjectView(dict(
         filename='my-file',
         stream='stream',
-        save=lambda file: None
+        save=lambda f: None
     ))
     data = {
         'scientific_name': 'Paul',
@@ -121,7 +121,7 @@ def test_scan_store_create_again(store):
     file = ObjectView(dict(
         filename='my-file',
         stream='stream',
-        save=lambda file: None
+        save=lambda f: None
     ))
     data = {
         'scientific_name': 'Paul',
@@ -231,7 +231,7 @@ def test_invalid_attachment(store, empty_zip):
     file = ObjectView(dict(
         filename='my-file',
         stream='stream',
-        save=lambda file: None
+        save=lambda f: None
     ))
     data = {
         'scientific_name': 'Paul',

--- a/app/data/test/test_scan_store.py
+++ b/app/data/test/test_scan_store.py
@@ -1,326 +1,342 @@
-from ..scan_store import ScanStore, AmbiguousZip, NoAuthor, InvalidAttachment, Unpublishable
-from ... import app, db, models
-import pytest
-from werkzeug.datastructures import FileStorage
 import os
 
+import pytest
+from werkzeug.datastructures import FileStorage
+
+from ..scan_store import ScanStore, AmbiguousZip, NoAuthor, InvalidAttachment, Unpublishable
+from ... import app, db, models
+
+
 class objectview(object):
-	def __init__(self, d):
-			self.__dict__ = d
+    def __init__(self, d):
+        self.__dict__ = d
+
 
 @pytest.fixture
 def database():
-	"""Create a client to test requests to the app"""
-	app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
-	app.testing = True
+    """Create a client to test requests to the app"""
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.testing = True
 
-	# Set up the app context
-	with app.app_context():
-		# Create database and admin user
-		db.create_all()
+    # Set up the app context
+    with app.app_context():
+        # Create database and admin user
+        db.create_all()
 
-		user = models.User(
-			name = 'Admin',
-			email = 'admin',
-			role = 'ADMIN'
-		)
-		user.setPassword('pass')
-		db.session.add(user)
-		db.session.commit()
+        user = models.User(
+            name='Admin',
+            email='admin',
+            role='ADMIN'
+        )
+        user.setPassword('pass')
+        db.session.add(user)
+        db.session.commit()
 
-		yield db
+        yield db
 
-	# Empty database for next test
-	db.drop_all()
+    # Empty database for next test
+    db.drop_all()
+
 
 @pytest.fixture
 def store(database):
-	return ScanStore(database)
+    return ScanStore(database)
+
 
 @pytest.fixture
 def zipFile():
-	f = open(os.path.dirname(__file__) + '/test.zip', 'rb')
+    f = open(os.path.dirname(__file__) + '/test.zip', 'rb')
 
-	yield f
+    yield f
 
-	f.close()
+    f.close()
+
 
 @pytest.fixture
 def emptyZip():
-	f = open(os.path.dirname(__file__) + '/empty.zip', 'rb')
+    f = open(os.path.dirname(__file__) + '/empty.zip', 'rb')
 
-	yield f
+    yield f
 
-	f.close()
+    f.close()
+
 
 @pytest.fixture
 def image():
-	f = open(os.path.dirname(__file__) + '/example.png', 'rb')
+    f = open(os.path.dirname(__file__) + '/example.png', 'rb')
 
-	yield f
+    yield f
 
-	f.close()
+    f.close()
+
 
 @pytest.fixture
 def horse():
-	horse = open(os.path.dirname(__file__) + '/../../../fixtures/Horse.zip', 'rb')
-	yield FileStorage(stream=horse, filename='horse.zip')
-	horse.close()
+    horse = open(os.path.dirname(__file__) + '/../../../fixtures/Horse.zip', 'rb')
+    yield FileStorage(stream=horse, filename='horse.zip')
+    horse.close()
+
 
 def test_scan_store_create(store, image):
-	file = objectview(dict(
-		filename = 'my-file',
-		stream = 'stream',
-		save = lambda file: None
-	))
-	data = {
-		'scientific_name': 'Paul',
-		'alt_name': 'alt name',
-		'specimen_location': 'specimen_location',
-		'specimen_id': 'specimen_id',
-		#'specimen_url': 'specimen_url',
-		'description': 'description',
-		'publications': [],
-		'geologic_age': [],
-		'ontogenic_age': [],
-		'elements': [],
-		'gbif_id': None,
-	}
+    file = objectview(dict(
+        filename='my-file',
+        stream='stream',
+        save=lambda file: None
+    ))
+    data = {
+        'scientific_name': 'Paul',
+        'alt_name': 'alt name',
+        'specimen_location': 'specimen_location',
+        'specimen_id': 'specimen_id',
+        # 'specimen_url': 'specimen_url',
+        'description': 'description',
+        'publications': [],
+        'geologic_age': [],
+        'ontogenic_age': [],
+        'elements': [],
+        'gbif_id': None,
+    }
 
-	attachments= [
-		FileStorage(
-			stream=image,
-			filename='image.png'
-		)
-	]
+    attachments = [
+        FileStorage(
+            stream=image,
+            filename='image.png'
+        )
+    ]
 
-	uri = store.create(
-		file,
-		'admin',
-		data,
-		attachments
-	)
+    uri = store.create(
+        file,
+        'admin',
+        data,
+        attachments
+    )
 
-	scan = store.get(uri)
+    scan = store.get(uri)
 
-	for key, value in data.items():
-		assert getattr(scan, key) == value
+    for key, value in data.items():
+        assert getattr(scan, key) == value
+
 
 def test_scan_store_create_again(store):
-	file = objectview(dict(
-		filename = 'my-file',
-		stream = 'stream',
-		save = lambda file: None
-	))
-	data = {
-		'scientific_name': 'Paul',
-		'alt_name': 'alt name',
-		'specimen_location': 'specimen_location',
-		'specimen_id': 'specimen_id',
-		#'specimen_url': 'specimen_url',
-		'description': 'description',
-		'publications': [],
-		'geologic_age': [],
-		'ontogenic_age': [],
-		'elements': [],
-		'gbif_id': 3,
-		'attachments': []
-	}
+    file = objectview(dict(
+        filename='my-file',
+        stream='stream',
+        save=lambda file: None
+    ))
+    data = {
+        'scientific_name': 'Paul',
+        'alt_name': 'alt name',
+        'specimen_location': 'specimen_location',
+        'specimen_id': 'specimen_id',
+        # 'specimen_url': 'specimen_url',
+        'description': 'description',
+        'publications': [],
+        'geologic_age': [],
+        'ontogenic_age': [],
+        'elements': [],
+        'gbif_id': 3,
+        'attachments': []
+    }
 
-	uri1 = store.create(
-		file,
-		'admin',
-		data
-	)
+    uri1 = store.create(
+        file,
+        'admin',
+        data
+    )
 
-	uri2 = store.create(
-		file,
-		'admin',
-		data
-	)
+    uri2 = store.create(
+        file,
+        'admin',
+        data
+    )
 
-	scan = store.get(uri2)
+    scan = store.get(uri2)
 
-	assert scan.url_slug == 'paul-2'
+    assert scan.url_slug == 'paul-2'
+
 
 def test_zip_upload(store, zipFile):
-	file = FileStorage(
-		stream = zipFile,
-		filename = 'my-file.zip'
-	)
-	data = {
-		'scientific_name': 'Paul',
-		'alt_name': 'alt name',
-		'specimen_location': 'specimen_location',
-		'specimen_id': 'specimen_id',
-		#'specimen_url': 'specimen_url',
-		'description': 'description',
-		'publications': [],
-		'geologic_age': [],
-		'ontogenic_age': [],
-		'elements': [],
-		'gbif_id': None,
-		'attachments': []
-	}
+    file = FileStorage(
+        stream=zipFile,
+        filename='my-file.zip'
+    )
+    data = {
+        'scientific_name': 'Paul',
+        'alt_name': 'alt name',
+        'specimen_location': 'specimen_location',
+        'specimen_id': 'specimen_id',
+        # 'specimen_url': 'specimen_url',
+        'description': 'description',
+        'publications': [],
+        'geologic_age': [],
+        'ontogenic_age': [],
+        'elements': [],
+        'gbif_id': None,
+        'attachments': []
+    }
 
-	scan = store.get(store.create(file, 'admin', data))
+    scan = store.get(store.create(file, 'admin', data))
 
-	assert scan.source != None
+    assert scan.source != None
 
 
 def test_empty_zip_upload(store, emptyZip):
-	print(os.path.dirname(__file__) + '/test.zip')
-	file = FileStorage(
-		stream = emptyZip,
-		filename = 'my-file.zip'
-	)
-	data = {
-		'scientific_name': 'Paul',
-		'alt_name': 'alt name',
-		'specimen_location': 'specimen_location',
-		'specimen_id': 'specimen_id',
-		#'specimen_url': 'specimen_url',
-		'description': 'description',
-		'publications': [],
-		'geologic_age': [],
-		'ontogenic_age': [],
-		'elements': [],
-		'gbif_id': None,
-		'attachments': []
-	}
+    print(os.path.dirname(__file__) + '/test.zip')
+    file = FileStorage(
+        stream=emptyZip,
+        filename='my-file.zip'
+    )
+    data = {
+        'scientific_name': 'Paul',
+        'alt_name': 'alt name',
+        'specimen_location': 'specimen_location',
+        'specimen_id': 'specimen_id',
+        # 'specimen_url': 'specimen_url',
+        'description': 'description',
+        'publications': [],
+        'geologic_age': [],
+        'ontogenic_age': [],
+        'elements': [],
+        'gbif_id': None,
+        'attachments': []
+    }
 
-	with pytest.raises(AmbiguousZip):
-		store.create(file, 'admin', data)
+    with pytest.raises(AmbiguousZip):
+        store.create(file, 'admin', data)
 
 
 def test_no_author(store):
-	print(os.path.dirname(__file__) + '/test.zip')
-	file = {}
-	data = {
-		'scientific_name': 'Paul',
-		'alt_name': 'alt name',
-		'specimen_location': 'specimen_location',
-		'specimen_id': 'specimen_id',
-		#'specimen_url': 'specimen_url',
-		'description': 'description',
-		'publications': [],
-		'geologic_age': [],
-		'ontogenic_age': [],
-		'elements': [],
-		'gbif_id': None,
-		'attachments': []
-	}
+    print(os.path.dirname(__file__) + '/test.zip')
+    file = {}
+    data = {
+        'scientific_name': 'Paul',
+        'alt_name': 'alt name',
+        'specimen_location': 'specimen_location',
+        'specimen_id': 'specimen_id',
+        # 'specimen_url': 'specimen_url',
+        'description': 'description',
+        'publications': [],
+        'geologic_age': [],
+        'ontogenic_age': [],
+        'elements': [],
+        'gbif_id': None,
+        'attachments': []
+    }
 
-	with pytest.raises(NoAuthor):
-		store.create(file, 'paul', data)
+    with pytest.raises(NoAuthor):
+        store.create(file, 'paul', data)
+
 
 def test_invalid_attachment(store, emptyZip):
-	file = objectview(dict(
-		filename = 'my-file',
-		stream = 'stream',
-		save = lambda file: None
-	))
-	data = {
-		'scientific_name': 'Paul',
-		'alt_name': 'alt name',
-		'specimen_location': 'specimen_location',
-		'specimen_id': 'specimen_id',
-		#'specimen_url': 'specimen_url',
-		'description': 'description',
-		'publications': [],
-		'geologic_age': [],
-		'ontogenic_age': [],
-		'elements': [],
-		'gbif_id': None
-	}
+    file = objectview(dict(
+        filename='my-file',
+        stream='stream',
+        save=lambda file: None
+    ))
+    data = {
+        'scientific_name': 'Paul',
+        'alt_name': 'alt name',
+        'specimen_location': 'specimen_location',
+        'specimen_id': 'specimen_id',
+        # 'specimen_url': 'specimen_url',
+        'description': 'description',
+        'publications': [],
+        'geologic_age': [],
+        'ontogenic_age': [],
+        'elements': [],
+        'gbif_id': None
+    }
 
-	attachments = [
-		FileStorage(
-			stream=emptyZip,
-			filename='zip.zip'
-		)
-	]
+    attachments = [
+        FileStorage(
+            stream=emptyZip,
+            filename='zip.zip'
+        )
+    ]
 
-	with pytest.raises(InvalidAttachment):
-		uri = store.create(
-			file,
-			'admin',
-			data,
-			attachments
-)
+    with pytest.raises(InvalidAttachment):
+        uri = store.create(
+            file,
+            'admin',
+            data,
+            attachments
+        )
+
 
 def test_publish(store, zipFile, image):
-	file = FileStorage(
-		stream = zipFile,
-		filename = 'my-file.zip'
-	)
-	data = {
-		'scientific_name': 'Paul',
-		'alt_name': 'alt name',
-		'specimen_location': 'specimen_location',
-		'specimen_id': 'specimen_id',
-		#'specimen_url': 'specimen_url',
-		'description': 'description',
-		'publications': [],
-		'geologic_age': [],
-		'ontogenic_age': [],
-		'elements': [],
-		'gbif_id': None
-	}
+    file = FileStorage(
+        stream=zipFile,
+        filename='my-file.zip'
+    )
+    data = {
+        'scientific_name': 'Paul',
+        'alt_name': 'alt name',
+        'specimen_location': 'specimen_location',
+        'specimen_id': 'specimen_id',
+        # 'specimen_url': 'specimen_url',
+        'description': 'description',
+        'publications': [],
+        'geologic_age': [],
+        'ontogenic_age': [],
+        'elements': [],
+        'gbif_id': None
+    }
 
-	attachments= [
-		FileStorage(
-			stream=image,
-			filename='image.png'
-		)
-	]
+    attachments = [
+        FileStorage(
+            stream=image,
+            filename='image.png'
+        )
+    ]
 
-	uri = store.create(file, 'admin', data, attachments)
-	store.publish(uri)
-	scan = store.get(uri)
+    uri = store.create(file, 'admin', data, attachments)
+    store.publish(uri)
+    scan = store.get(uri)
 
-	assert scan.published == True
+    assert scan.published == True
+
 
 def test_unpublishable(store):
-	file = None
-	data = {
-		'scientific_name': 'Paul',
-		'alt_name': 'alt name',
-		'specimen_location': 'specimen_location',
-		'specimen_id': 'specimen_id',
-		#'specimen_url': 'specimen_url',
-		'description': 'description',
-		'publications': [],
-		'geologic_age': [],
-		'ontogenic_age': [],
-		'elements': [],
-		'gbif_id': None
-	}
+    file = None
+    data = {
+        'scientific_name': 'Paul',
+        'alt_name': 'alt name',
+        'specimen_location': 'specimen_location',
+        'specimen_id': 'specimen_id',
+        # 'specimen_url': 'specimen_url',
+        'description': 'description',
+        'publications': [],
+        'geologic_age': [],
+        'ontogenic_age': [],
+        'elements': [],
+        'gbif_id': None
+    }
 
-	uri=store.create(file, 'admin', data)
+    uri = store.create(file, 'admin', data)
 
-	with pytest.raises(Unpublishable):
-		store.publish(uri)
+    with pytest.raises(Unpublishable):
+        store.publish(uri)
+
 
 def test_create_ctm(store, horse):
-	"""Test to make sure an uploaded file gets processed"""
-	data = {
-		'scientific_name': 'Paul',
-		'alt_name': 'alt name',
-		'specimen_location': 'specimen_location',
-		'specimen_id': 'specimen_id',
-		#'specimen_url': 'specimen_url',
-		'description': 'description',
-		'publications': [],
-		'geologic_age': [],
-		'ontogenic_age': [],
-		'elements': [],
-		'gbif_id': None
-	}
+    """Test to make sure an uploaded file gets processed"""
+    data = {
+        'scientific_name': 'Paul',
+        'alt_name': 'alt name',
+        'specimen_location': 'specimen_location',
+        'specimen_id': 'specimen_id',
+        # 'specimen_url': 'specimen_url',
+        'description': 'description',
+        'publications': [],
+        'geologic_age': [],
+        'ontogenic_age': [],
+        'elements': [],
+        'gbif_id': None
+    }
 
-	slug = store.create(horse, 'admin', data, [])
-	store.create_ctm(slug)
+    slug = store.create(horse, 'admin', data, [])
+    store.create_ctm(slug)
 
-	scan = store.get(slug)
+    scan = store.get(slug)
 
-	assert scan.ctm != None
+    assert scan.ctm != None

--- a/app/data/test/test_scan_store.py
+++ b/app/data/test/test_scan_store.py
@@ -7,7 +7,7 @@ from ..scan_store import ScanStore, AmbiguousZip, NoAuthor, InvalidAttachment, U
 from ... import app, db, models
 
 
-class objectview(object):
+class ObjectView(object):
     def __init__(self, d):
         self.__dict__ = d
 
@@ -44,7 +44,7 @@ def store(database):
 
 
 @pytest.fixture
-def zipFile():
+def zip_file():
     f = open(os.path.dirname(__file__) + '/test.zip', 'rb')
 
     yield f
@@ -53,7 +53,7 @@ def zipFile():
 
 
 @pytest.fixture
-def emptyZip():
+def empty_zip():
     f = open(os.path.dirname(__file__) + '/empty.zip', 'rb')
 
     yield f
@@ -78,7 +78,7 @@ def horse():
 
 
 def test_scan_store_create(store, image):
-    file = objectview(dict(
+    file = ObjectView(dict(
         filename='my-file',
         stream='stream',
         save=lambda file: None
@@ -118,7 +118,7 @@ def test_scan_store_create(store, image):
 
 
 def test_scan_store_create_again(store):
-    file = objectview(dict(
+    file = ObjectView(dict(
         filename='my-file',
         stream='stream',
         save=lambda file: None
@@ -155,9 +155,9 @@ def test_scan_store_create_again(store):
     assert scan.url_slug == 'paul-2'
 
 
-def test_zip_upload(store, zipFile):
+def test_zip_upload(store, zip_file):
     file = FileStorage(
-        stream=zipFile,
+        stream=zip_file,
         filename='my-file.zip'
     )
     data = {
@@ -180,10 +180,10 @@ def test_zip_upload(store, zipFile):
     assert scan.source is not None
 
 
-def test_empty_zip_upload(store, emptyZip):
+def test_empty_zip_upload(store, empty_zip):
     print(os.path.dirname(__file__) + '/test.zip')
     file = FileStorage(
-        stream=emptyZip,
+        stream=empty_zip,
         filename='my-file.zip'
     )
     data = {
@@ -227,8 +227,8 @@ def test_no_author(store):
         store.create(file, 'paul', data)
 
 
-def test_invalid_attachment(store, emptyZip):
-    file = objectview(dict(
+def test_invalid_attachment(store, empty_zip):
+    file = ObjectView(dict(
         filename='my-file',
         stream='stream',
         save=lambda file: None
@@ -249,7 +249,7 @@ def test_invalid_attachment(store, emptyZip):
 
     attachments = [
         FileStorage(
-            stream=emptyZip,
+            stream=empty_zip,
             filename='zip.zip'
         )
     ]
@@ -263,9 +263,9 @@ def test_invalid_attachment(store, emptyZip):
         )
 
 
-def test_publish(store, zipFile, image):
+def test_publish(store, zip_file, image):
     file = FileStorage(
-        stream=zipFile,
+        stream=zip_file,
         filename='my-file.zip'
     )
     data = {

--- a/app/data/test/test_tmp_upload_store.py
+++ b/app/data/test/test_tmp_upload_store.py
@@ -1,22 +1,26 @@
-from ..tmp_upload_store import TmpUploadStore
 import pytest
+
+from ..tmp_upload_store import TmpUploadStore
+
 
 @pytest.fixture
 def store():
-	return TmpUploadStore('/tmp/upload_')
+    return TmpUploadStore('/tmp/upload_')
+
 
 def test_get_name(store):
-	with pytest.raises(ValueError):
-		store.getFilepath('test')
+    with pytest.raises(ValueError):
+        store.getFilepath('test')
 
-	uuid = '22383093-099b-4823-9cbb-02f925b6423d'
-	assert store.getFilepath(uuid) == '/tmp/upload_'+uuid
+    uuid = '22383093-099b-4823-9cbb-02f925b6423d'
+    assert store.getFilepath(uuid) == '/tmp/upload_' + uuid
+
 
 def test_write_to_file(store):
-	id = store.create()
+    id = store.create()
 
-	store.append(id, b'string a')
-	store.append(id, b'string b')
+    store.append(id, b'string a')
+    store.append(id, b'string b')
 
-	with open(store.getFilepath(id), 'r') as file:
-		assert file.read() == 'string astring b'
+    with open(store.getFilepath(id), 'r') as file:
+        assert file.read() == 'string astring b'

--- a/app/data/test/test_tmp_upload_store.py
+++ b/app/data/test/test_tmp_upload_store.py
@@ -17,10 +17,10 @@ def test_get_name(store):
 
 
 def test_write_to_file(store):
-    id = store.create()
+    file_id = store.create()
 
-    store.append(id, b'string a')
-    store.append(id, b'string b')
+    store.append(file_id, b'string a')
+    store.append(file_id, b'string b')
 
-    with open(store.get_filepath(id), 'r') as file:
+    with open(store.get_filepath(file_id), 'r') as file:
         assert file.read() == 'string astring b'

--- a/app/data/test/test_tmp_upload_store.py
+++ b/app/data/test/test_tmp_upload_store.py
@@ -10,10 +10,10 @@ def store():
 
 def test_get_name(store):
     with pytest.raises(ValueError):
-        store.getFilepath('test')
+        store.get_filepath('test')
 
     uuid = '22383093-099b-4823-9cbb-02f925b6423d'
-    assert store.getFilepath(uuid) == '/tmp/upload_' + uuid
+    assert store.get_filepath(uuid) == '/tmp/upload_' + uuid
 
 
 def test_write_to_file(store):
@@ -22,5 +22,5 @@ def test_write_to_file(store):
     store.append(id, b'string a')
     store.append(id, b'string b')
 
-    with open(store.getFilepath(id), 'r') as file:
+    with open(store.get_filepath(id), 'r') as file:
         assert file.read() == 'string astring b'

--- a/app/data/tmp_upload_store.py
+++ b/app/data/tmp_upload_store.py
@@ -5,17 +5,17 @@ class TmpUploadStore:
     def __init__(self, prefix):
         self.prefix = prefix
 
-    def get_filepath(self, id):
+    def get_filepath(self, file_id):
         # Validate the ID is a uuid
-        uuid.UUID(id, version=4)
-        return self.prefix + id
+        uuid.UUID(file_id, version=4)
+        return self.prefix + file_id
 
     def create(self):
-        id = str(uuid.uuid4())
-        return id
+        file_id = str(uuid.uuid4())
+        return file_id
 
-    def append(self, id, data):
-        filename = self.get_filepath(id)
+    def append(self, file_id, data):
+        filename = self.get_filepath(file_id)
         file = open(filename, 'ab')
         file.write(data)
         file.close()

--- a/app/data/tmp_upload_store.py
+++ b/app/data/tmp_upload_store.py
@@ -1,20 +1,21 @@
 import uuid
 
+
 class TmpUploadStore:
-	def __init__(self, prefix):
-		self.prefix = prefix
+    def __init__(self, prefix):
+        self.prefix = prefix
 
-	def getFilepath(self, id):
-		# Validate the ID is a uuid
-		uuid.UUID(id, version=4)
-		return self.prefix + id
+    def getFilepath(self, id):
+        # Validate the ID is a uuid
+        uuid.UUID(id, version=4)
+        return self.prefix + id
 
-	def create(self):
-		id = str(uuid.uuid4())
-		return id
+    def create(self):
+        id = str(uuid.uuid4())
+        return id
 
-	def append(self, id, data):
-		filename = self.getFilepath(id)
-		file = open(filename, 'ab')
-		file.write(data)
-		file.close()
+    def append(self, id, data):
+        filename = self.getFilepath(id)
+        file = open(filename, 'ab')
+        file.write(data)
+        file.close()

--- a/app/data/tmp_upload_store.py
+++ b/app/data/tmp_upload_store.py
@@ -5,7 +5,7 @@ class TmpUploadStore:
     def __init__(self, prefix):
         self.prefix = prefix
 
-    def getFilepath(self, id):
+    def get_filepath(self, id):
         # Validate the ID is a uuid
         uuid.UUID(id, version=4)
         return self.prefix + id
@@ -15,7 +15,7 @@ class TmpUploadStore:
         return id
 
     def append(self, id, data):
-        filename = self.getFilepath(id)
+        filename = self.get_filepath(id)
         file = open(filename, 'ab')
         file.write(data)
         file.close()

--- a/app/errors.py
+++ b/app/errors.py
@@ -1,13 +1,17 @@
 from flask import render_template
+
 from app import app, db
+
 
 @app.errorhandler(403)
 def forbidden_error(error):
     return render_template('403.html', message=error.description), 403
 
+
 @app.errorhandler(404)
 def not_found_error(error):
     return render_template('404.html'), 404
+
 
 @app.errorhandler(500)
 def internal_error(error):

--- a/app/forms.py
+++ b/app/forms.py
@@ -59,19 +59,19 @@ class ScanUploadForm(FlaskForm):
     specimen_url = StringField('Additional Media')
     description = TextAreaField('Description')
     publications = SelectMultipleField('Publications', choices=[],
-                                       coerce=lambda id: id if isinstance(id, Publication) else Publication.query.get(
-                                           int(id)), widget=widgets.ListWidget(), option_widget=widgets.CheckboxInput())
+                                       coerce=lambda f: f if isinstance(f, Publication) else Publication.query.get(
+                                           int(f)), widget=widgets.ListWidget(), option_widget=widgets.CheckboxInput())
     attachments = MultipleFileField('Add files', default=[])
     geologic_age = SelectMultipleField('Geologic Age', choices=[],
-                                       coerce=lambda id: id if isinstance(id, Tag) else Tag.query.get(int(id)),
+                                       coerce=lambda f: f if isinstance(f, Tag) else Tag.query.get(int(f)),
                                        widget=widgets.ListWidget(), option_widget=widgets.CheckboxInput(),
                                        validators=[DataRequired()])
     ontogenic_age = SelectMultipleField('Ontogenetic Age', choices=[],
-                                        coerce=lambda id: id if isinstance(id, Tag) else Tag.query.get(int(id)),
+                                        coerce=lambda f: f if isinstance(f, Tag) else Tag.query.get(int(f)),
                                         widget=widgets.ListWidget(), option_widget=widgets.CheckboxInput(),
                                         validators=[DataRequired()])
     elements = SelectMultipleField('Elements', choices=[],
-                                   coerce=lambda id: id if isinstance(id, Tag) else Tag.query.get(int(id)),
+                                   coerce=lambda f: f if isinstance(f, Tag) else Tag.query.get(int(f)),
                                    widget=widgets.ListWidget(), option_widget=widgets.CheckboxInput(),
                                    validators=[DataRequired()])
     gbif_id = StringField()

--- a/app/forms.py
+++ b/app/forms.py
@@ -85,7 +85,7 @@ class ScanUploadForm(FlaskForm):
         self.elements.choices = [(tag, tag) for tag in Tag.query.filter_by(category='elements').all()]
 
     def serialize(self):
-        data = {
+        serialized_data = {
             k: {
                 'data': (None if isinstance(self[k], FileField)
                          else ([datum.serialize() if isinstance(datum, db.Model)
@@ -100,9 +100,9 @@ class ScanUploadForm(FlaskForm):
         tag_tree = Tag.tree()
         for key in ('geologic_age', 'ontogenic_age', 'elements'):
             if key in tag_tree:
-                data[key]['choices'] = tag_tree[key]
+                serialized_data[key]['choices'] = tag_tree[key]
 
-        return data
+        return serialized_data
 
 
 class PublicationUploadForm(FlaskForm):

--- a/app/forms.py
+++ b/app/forms.py
@@ -2,8 +2,9 @@ import json
 import urllib.request
 
 from flask_wtf import FlaskForm
-from wtforms import widgets, StringField, PasswordField, BooleanField, SubmitField, HiddenField, SelectField, FileField, \
-    TextAreaField, MultipleFileField, SelectMultipleField
+from wtforms import (widgets, StringField, PasswordField, BooleanField,
+                     SubmitField, HiddenField, SelectField, FileField,
+                     TextAreaField, MultipleFileField, SelectMultipleField)
 from wtforms.validators import DataRequired, Email, ValidationError
 
 from app import db
@@ -86,19 +87,20 @@ class ScanUploadForm(FlaskForm):
     def serialize(self):
         data = {
             k: {
-                'data': None if isinstance(self[k], FileField) else [
-                    datum.serialize() if isinstance(datum, db.Model) else datum for datum in v] if isinstance(v,
-                                                                                                              list) else v,
+                'data': (None if isinstance(self[k], FileField)
+                         else ([datum.serialize() if isinstance(datum, db.Model)
+                                else datum for datum in v] if isinstance(v, list)
+                               else v)),
                 'errors': self[k].errors,
                 'choices': [choice[0].serialize() if isinstance(choice[0], db.Model) else choice for choice in
                             self[k].choices] if isinstance(self[k], SelectMultipleField) else None
             } for k, v in self.data.items()
         }
 
-        tagTree = Tag.tree()
+        tag_tree = Tag.tree()
         for key in ('geologic_age', 'ontogenic_age', 'elements'):
-            if key in tagTree:
-                data[key]['choices'] = tagTree[key]
+            if key in tag_tree:
+                data[key]['choices'] = tag_tree[key]
 
         return data
 

--- a/app/forms.py
+++ b/app/forms.py
@@ -1,13 +1,17 @@
-from flask_wtf import FlaskForm
-from wtforms import widgets, StringField, PasswordField, BooleanField, SubmitField, HiddenField, SelectField, FileField, TextAreaField, MultipleFileField, SelectMultipleField
-from wtforms.validators import DataRequired, Email, ValidationError
-from flask_wtf.file import FileRequired, FileAllowed
-import json, urllib.request
-from app.models import User, Tag, Publication
-from app import db, app
+import json
+import urllib.request
 
-data = urllib.request.urlopen("http://country.io/names.json").read()
+from flask_wtf import FlaskForm
+from wtforms import widgets, StringField, PasswordField, BooleanField, SubmitField, HiddenField, SelectField, FileField, \
+    TextAreaField, MultipleFileField, SelectMultipleField
+from wtforms.validators import DataRequired, Email, ValidationError
+
+from app import db
+from app.models import User, Tag, Publication
+
+data = urllib.request.urlopen('http://country.io/names.json').read()
 countries = list(json.loads(data).items())
+
 
 class LoginForm(FlaskForm):
     email = StringField('Email address', validators=[DataRequired()])
@@ -15,6 +19,7 @@ class LoginForm(FlaskForm):
     remember_me = BooleanField('Remember Me')
     submit = SubmitField('Sign In')
     next = HiddenField()
+
 
 class RegistrationForm(FlaskForm):
     name = StringField('Name', validators=[DataRequired()])
@@ -33,6 +38,7 @@ class RegistrationForm(FlaskForm):
         ]
     )
     submit = SubmitField('Sign up')
+
     # Todo: Use input & datalist instead of country select field
     # Validate/resolve against https://restcountries.eu/#api-endpoints-name
 
@@ -41,45 +47,61 @@ class RegistrationForm(FlaskForm):
         if user is not None:
             raise ValidationError('Please use a different email address.')
 
+
 class ScanUploadForm(FlaskForm):
     file = FileField('Scan file')
     stills = MultipleFileField('Stills')
-    scientific_name = StringField('Scientific Name', validators = [DataRequired()])
+    scientific_name = StringField('Scientific Name', validators=[DataRequired()])
     alt_name = StringField('Alternate Name')
     specimen_location = StringField('Specimen Location')
     specimen_id = StringField('Specimen ID')
     specimen_url = StringField('Additional Media')
     description = TextAreaField('Description')
-    publications = SelectMultipleField('Publications', choices = [], coerce = lambda id: id if isinstance(id, Publication) else Publication.query.get(int(id)), widget=widgets.ListWidget(), option_widget=widgets.CheckboxInput())
-    attachments = MultipleFileField('Add files', default = [])
-    geologic_age = SelectMultipleField('Geologic Age', choices = [], coerce = lambda id: id if isinstance(id, Tag) else Tag.query.get(int(id)), widget=widgets.ListWidget(), option_widget=widgets.CheckboxInput(), validators=[DataRequired()])
-    ontogenic_age = SelectMultipleField('Ontogenetic Age', choices = [], coerce = lambda id: id if isinstance(id, Tag) else Tag.query.get(int(id)), widget=widgets.ListWidget(), option_widget=widgets.CheckboxInput(), validators=[DataRequired()])
-    elements = SelectMultipleField('Elements', choices = [], coerce = lambda id: id if isinstance(id, Tag) else Tag.query.get(int(id)), widget=widgets.ListWidget(), option_widget=widgets.CheckboxInput(), validators=[DataRequired()])
+    publications = SelectMultipleField('Publications', choices=[],
+                                       coerce=lambda id: id if isinstance(id, Publication) else Publication.query.get(
+                                           int(id)), widget=widgets.ListWidget(), option_widget=widgets.CheckboxInput())
+    attachments = MultipleFileField('Add files', default=[])
+    geologic_age = SelectMultipleField('Geologic Age', choices=[],
+                                       coerce=lambda id: id if isinstance(id, Tag) else Tag.query.get(int(id)),
+                                       widget=widgets.ListWidget(), option_widget=widgets.CheckboxInput(),
+                                       validators=[DataRequired()])
+    ontogenic_age = SelectMultipleField('Ontogenetic Age', choices=[],
+                                        coerce=lambda id: id if isinstance(id, Tag) else Tag.query.get(int(id)),
+                                        widget=widgets.ListWidget(), option_widget=widgets.CheckboxInput(),
+                                        validators=[DataRequired()])
+    elements = SelectMultipleField('Elements', choices=[],
+                                   coerce=lambda id: id if isinstance(id, Tag) else Tag.query.get(int(id)),
+                                   widget=widgets.ListWidget(), option_widget=widgets.CheckboxInput(),
+                                   validators=[DataRequired()])
     gbif_id = StringField()
     published = BooleanField('Publish')
     submit = SubmitField('Save')
 
-    def __init__(self, *args,**kwargs):
-        super(ScanUploadForm, self).__init__(*args,**kwargs)
-        self.geologic_age.choices = [ (tag, tag) for tag in Tag.query.filter_by(category='geologic_age').all() ]
-        self.ontogenic_age.choices = [ (tag, tag) for tag in Tag.query.filter_by(category='ontogenic_age').all() ]
-        self.elements.choices = [ (tag, tag) for tag in Tag.query.filter_by(category='elements').all() ]
+    def __init__(self, *args, **kwargs):
+        super(ScanUploadForm, self).__init__(*args, **kwargs)
+        self.geologic_age.choices = [(tag, tag) for tag in Tag.query.filter_by(category='geologic_age').all()]
+        self.ontogenic_age.choices = [(tag, tag) for tag in Tag.query.filter_by(category='ontogenic_age').all()]
+        self.elements.choices = [(tag, tag) for tag in Tag.query.filter_by(category='elements').all()]
 
     def serialize(self):
         data = {
             k: {
-                'data': None if isinstance(self[k], FileField) else [ datum.serialize() if isinstance(datum, db.Model) else datum for datum in v ] if isinstance(v, list) else v,
+                'data': None if isinstance(self[k], FileField) else [
+                    datum.serialize() if isinstance(datum, db.Model) else datum for datum in v] if isinstance(v,
+                                                                                                              list) else v,
                 'errors': self[k].errors,
-                'choices': [ choice[0].serialize() if isinstance(choice[0], db.Model) else choice for choice in self[k].choices ] if isinstance(self[k], SelectMultipleField) else None
+                'choices': [choice[0].serialize() if isinstance(choice[0], db.Model) else choice for choice in
+                            self[k].choices] if isinstance(self[k], SelectMultipleField) else None
             } for k, v in self.data.items()
         }
 
         tagTree = Tag.tree()
-        for key in ('geologic_age','ontogenic_age','elements'):
+        for key in ('geologic_age', 'ontogenic_age', 'elements'):
             if key in tagTree:
                 data[key]['choices'] = tagTree[key]
 
         return data
+
 
 class PublicationUploadForm(FlaskForm):
     title = StringField('Title', validators=[DataRequired()])
@@ -89,7 +111,7 @@ class PublicationUploadForm(FlaskForm):
     abstract = TextAreaField('Abstract', validators=[DataRequired()])
     link = StringField('URL Link')
     # TODO: Validate pdf files only
-    files = MultipleFileField('Add files', default = [])
+    files = MultipleFileField('Add files', default=[])
 
     # Return the json-serializable object representation of this form
     def serialize(self):

--- a/app/gbif.py
+++ b/app/gbif.py
@@ -1,21 +1,24 @@
-import urllib.request, json
-from app.models import Taxonomy, Scan, db
+import json
+import urllib.request
+
+from app.models import Taxonomy
 
 
 def fetch_json(url):
-  with urllib.request.urlopen(url) as response:
-    return json.loads(response.read().decode())
+    with urllib.request.urlopen(url) as response:
+        return json.loads(response.read().decode())
+
 
 def pull_tags(gbif_id):
-  gbif_api_url = "http://api.gbif.org/v1/species/" + str(gbif_id)
-  gbif_api_parents = gbif_api_url + "/parents"
+    gbif_api_url = 'http://api.gbif.org/v1/species/' + str(gbif_id)
+    gbif_api_parents = gbif_api_url + '/parents'
 
-  tags = fetch_json(gbif_api_parents) + [fetch_json(gbif_api_url)]
+    tags = fetch_json(gbif_api_parents) + [fetch_json(gbif_api_url)]
 
-  return [
-    Taxonomy(
-      id = tag['key'],
-      name = tag['vernacularName'] if 'vernacularName' in tag else tag['canonicalName'],
-      parent_id = tag['parentKey'] if 'parentKey' in tag else None
-    ) for tag in tags
-  ]
+    return [
+        Taxonomy(
+            id=tag['key'],
+            name=tag['vernacularName'] if 'vernacularName' in tag else tag['canonicalName'],
+            parent_id=tag['parentKey'] if 'parentKey' in tag else None
+        ) for tag in tags
+    ]

--- a/app/models.py
+++ b/app/models.py
@@ -18,7 +18,7 @@ def load_user(user_id):
 
 
 # Allow decoding phpasswords, but deprecate all but argon2
-cryptCtx = CryptContext(
+crypt_ctx = CryptContext(
     schemes=['argon2', 'phpass'],
     deprecated=['auto']
 )
@@ -43,13 +43,13 @@ class User(UserMixin, db.Model):
         return self.is_admin() or self.role == 'CONTRIBUTOR'
 
     def set_password(self, password):
-        self.password = cryptCtx.hash(password)
+        self.password = crypt_ctx.hash(password)
 
     def check_password(self, password):
-        return cryptCtx.verify(password, self.password)
+        return crypt_ctx.verify(password, self.password)
 
     def password_needs_update(self):
-        return cryptCtx.needs_update(self.password)
+        return crypt_ctx.needs_update(self.password)
 
     def check_and_migrate_password(self, password):
         if self.check_password(password):

--- a/app/models.py
+++ b/app/models.py
@@ -239,7 +239,7 @@ class File(db.Model):
             app.config['MODEL_DIRECTORY'] if storage_area == File.MODELS_DIR else \
                 None
 
-        if storage_dir == None:
+        if storage_dir is None:
             raise Exception('No filesystem path is configured for storage area named ' + storage_area)
 
         return os.path.join(storage_dir, location)
@@ -482,7 +482,7 @@ class Queue(db.Model):
     @staticmethod
     def get():
         task = Queue.query.order_by('created').first()
-        if task == None:
+        if task is None:
             return None
 
         method = task.method
@@ -498,7 +498,7 @@ class Queue(db.Model):
         import time
         while True:
             task = Queue.get()
-            if task == None:
+            if task is None:
                 time.sleep(sleep)
             else:
                 yield task

--- a/app/models.py
+++ b/app/models.py
@@ -13,8 +13,8 @@ from app import db, login, app
 
 
 @login.user_loader
-def load_user(id):
-    return User.query.get(int(id))
+def load_user(user_id):
+    return User.query.get(int(user_id))
 
 
 # Allow decoding phpasswords, but deprecate all but argon2

--- a/app/models.py
+++ b/app/models.py
@@ -52,8 +52,8 @@ class User(UserMixin, db.Model):
         return cryptCtx.needs_update(self.password)
 
     def check_and_migrate_password(self, password):
-        if (self.check_password(password)):
-            if (self.password_needs_update()):
+        if self.check_password(password):
+            if self.password_needs_update():
                 self.set_password(password)
             return True
         return False

--- a/app/routes.py
+++ b/app/routes.py
@@ -15,15 +15,13 @@ from werkzeug.exceptions import NotFound, BadRequest, Forbidden
 from werkzeug.routing import ValidationError, BaseConverter, PathConverter
 from werkzeug.urls import url_parse
 
-from app import app, db, models, scan_store
-from app import mail
-from app import rpc
+from app import app, db, models, scan_store, rpc, mail
+from app.data.scan_store import ScanException
+from app.data.slugs import generate_slug
+from app.data.tmp_upload_store import TmpUploadStore
 from app.forms import LoginForm, RegistrationForm, ScanUploadForm, PublicationUploadForm
 from app.models import User, Scan, File, Publication, Tag, Taxonomy, Attachment, ScanAttachment, PublicationFile
-from .data.scan_store import ScanException
-from .data.slugs import generate_slug
-from .data.tmp_upload_store import TmpUploadStore
-from .tasks.client import TaskQueue
+from app.tasks.client import TaskQueue
 
 upload_store = TmpUploadStore(app.config['TMP_UPLOAD'])
 task_queue = TaskQueue(models.Queue)

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,26 +1,25 @@
-import os
-import uuid
+import io
 import math
+import os
 from functools import wraps
 from zipfile import ZipFile
-from flask import request, render_template, redirect, url_for, flash, send_from_directory, jsonify, g, Response, send_file, make_response
+
+from PIL import Image
+from flask import request, render_template, redirect, url_for, flash, send_from_directory, jsonify, g, Response, \
+  send_file, make_response
 from flask.helpers import safe_join
 from flask_login import current_user, login_user, login_required, logout_user
+from flask_mail import Message
+from werkzeug.datastructures import FileStorage
+from werkzeug.exceptions import NotFound, BadRequest, Forbidden
 from werkzeug.routing import ValidationError, BaseConverter, PathConverter
 from werkzeug.urls import url_parse
-from werkzeug.utils import secure_filename
-from werkzeug.exceptions import NotFound, BadRequest, Forbidden
-from werkzeug.datastructures import FileStorage
+
 from app import app, db, models, scanStore
-from app.forms import LoginForm, RegistrationForm, ScanUploadForm, PublicationUploadForm
-from app.models import User, Scan, File, Publication, Tag, Taxonomy, Attachment, ScanAttachment, PublicationFile
-import mimetypes
-import json
-from PIL import Image
-import io
-from flask_mail import Message
 from app import mail
 from app import rpc
+from app.forms import LoginForm, RegistrationForm, ScanUploadForm, PublicationUploadForm
+from app.models import User, Scan, File, Publication, Tag, Taxonomy, Attachment, ScanAttachment, PublicationFile
 from .data.scan_store import ScanException
 from .data.slugs import generate_slug
 from .data.tmp_upload_store import TmpUploadStore
@@ -29,128 +28,147 @@ from .tasks.client import TaskQueue
 uploadStore = TmpUploadStore(app.config['TMP_UPLOAD'])
 taskQueue = TaskQueue(models.Queue)
 
+
 def hideScanFiles(data):
-  if not current_user.is_authenticated:
-    login = url_for('login')
-    data['source'] = login
-    for pub in data['publications']:
-      for file in pub['files']:
-        file['file'] = login
-  return data
+    if not current_user.is_authenticated:
+        login = url_for('login')
+        data['source'] = login
+        for pub in data['publications']:
+            for file in pub['files']:
+                file['file'] = login
+    return data
+
 
 def ensureEditable(item):
-  """ Throw Forbidden exception if the current user is not allowed to edit the given model """
-  if not current_user.canEdit(item):
-      raise Forbidden('You cannot edit this item as you are not the original author.')
+    """ Throw Forbidden exception if the current user is not allowed to edit the given model """
+    if not current_user.canEdit(item):
+        raise Forbidden('You cannot edit this item as you are not the original author.')
+
 
 class SlugConverter(BaseConverter):
-  regex = r'[^/]+'
-  model = None
+    regex = r'[^/]+'
+    model = None
 
-  def to_python(self, slug):
-    model = self.model.findBySlug(slug)
-    if model == None:
-      raise ValidationError
-    return model
+    def to_python(self, slug):
+        model = self.model.findBySlug(slug)
+        if model == None:
+            raise ValidationError
+        return model
 
-  def to_url(self, value):
-    return BaseConverter.to_url(self, value.url_slug or value.id)
+    def to_url(self, value):
+        return BaseConverter.to_url(self, value.url_slug or value.id)
+
 
 class ScanConverter(SlugConverter):
-  model = Scan
+    model = Scan
+
 
 class PublicationConverter(SlugConverter):
-  model = Publication
+    model = Publication
+
 
 # This is just a one-way converter, to turn a File object into a router path. Doesn't work the other way.
 class FileConverter(PathConverter):
-  def to_url(self, value):
-    return PathConverter.to_url(self, value if isinstance(value, str) else value.location)
+    def to_url(self, value):
+        return PathConverter.to_url(self, value if isinstance(value, str) else value.location)
+
 
 app.url_map.converters['scan'] = ScanConverter
 app.url_map.converters['publication'] = PublicationConverter
 app.url_map.converters['file'] = FileConverter
+
 
 @app.after_request
 def add_headers(response):
     response.headers['X-Frame-Options'] = 'DENY'
     return response
 
+
 def requiresAdmin(f):
     @wraps(f)
     @login_required
     def decorated_function(*args, **kwargs):
         if not current_user.isAdmin():
-            return render_template('403.html', message='You must be an administrator to access this page.', menu='home') ,403
+            return render_template('403.html', message='You must be an administrator to access this page.',
+                                   menu='home'), 403
         return f(*args, **kwargs)
+
     return decorated_function
+
 
 def requiresContributor(f):
     @wraps(f)
     @login_required
     def decorated_function(*args, **kwargs):
         if not current_user.isContributor():
-            return render_template('403.html', message='You must be a contributor to access this page.', menu='home') ,403
+            return render_template('403.html', message='You must be a contributor to access this page.',
+                                   menu='home'), 403
         return f(*args, **kwargs)
+
     return decorated_function
+
 
 @app.route('/', methods=['GET', 'POST'])
 def index():
-  return render_template('index.html', menu='home')
+    return render_template('index.html', menu='home')
+
 
 @app.route('/models/<file:path>')
 def send_models(path):
-  """Url for downloading the source model file"""
-  return send_from_directory(app.config['MODEL_DIRECTORY'], path)
+    """Url for downloading the source model file"""
+    return send_from_directory(app.config['MODEL_DIRECTORY'], path)
+
 
 @app.route('/uploads/<file:path>')
 def send_uploads(path):
-  """Route for downloading an uploaded file. Images may be resized using the `w` parameter to specify width"""
-  width = request.args.get('w')
+    """Route for downloading an uploaded file. Images may be resized using the `w` parameter to specify width"""
+    width = request.args.get('w')
 
-  if width == None:
-    return send_from_directory(app.config['UPLOAD_DIRECTORY'], path)
+    if width == None:
+        return send_from_directory(app.config['UPLOAD_DIRECTORY'], path)
 
-  thumbnail_file = path + '-' + width + '.png'
-
-  try:
-    return send_from_directory(app.config['THUMB_DIRECTORY'], thumbnail_file)
-  except NotFound:
-    thumbnail_file = safe_join(app.config['THUMB_DIRECTORY'], thumbnail_file)
+    thumbnail_file = path + '-' + width + '.png'
 
     try:
-      width = int(width)
-    except ValueError:
-      raise BadRequest('Thumbnail width must be an integer number')
+        return send_from_directory(app.config['THUMB_DIRECTORY'], thumbnail_file)
+    except NotFound:
+        thumbnail_file = safe_join(app.config['THUMB_DIRECTORY'], thumbnail_file)
 
-    if width < 1:
-      raise BadRequest('Thumbnail width must be greater than zero')
+        try:
+            width = int(width)
+        except ValueError:
+            raise BadRequest('Thumbnail width must be an integer number')
 
-    try:
-      im = Image.open(safe_join(app.config['UPLOAD_DIRECTORY'], path))
-    except FileNotFoundError:
-      raise NotFound()
-    except OSError:
-      raise BadRequest()
+        if width < 1:
+            raise BadRequest('Thumbnail width must be greater than zero')
 
-    if(width >= im.width):
-      return send_from_directory(app.config['UPLOAD_DIRECTORY'], path)
+        try:
+            im = Image.open(safe_join(app.config['UPLOAD_DIRECTORY'], path))
+        except FileNotFoundError:
+            raise NotFound()
+        except OSError:
+            raise BadRequest()
 
-    try:
-      os.makedirs(os.path.dirname(thumbnail_file))
-    except FileExistsError:
-      pass
+        if (width >= im.width):
+            return send_from_directory(app.config['UPLOAD_DIRECTORY'], path)
 
-    height = im.height * width / im.width
-    im.thumbnail((width, height))
-    byteIO = io.BytesIO()
-    im.save(byteIO, format='PNG')
-    im.save(thumbnail_file, format='PNG')
-    return Response(byteIO.getvalue(), mimetype="image/png", direct_passthrough=True)
+        try:
+            os.makedirs(os.path.dirname(thumbnail_file))
+        except FileExistsError:
+            pass
+
+        height = im.height * width / im.width
+        im.thumbnail((width, height))
+        byteIO = io.BytesIO()
+        im.save(byteIO, format='PNG')
+        im.save(thumbnail_file, format='PNG')
+        return Response(byteIO.getvalue(), mimetype='image/png', direct_passthrough=True)
+
 
 @app.route('/about/', methods=['GET', 'POST'])
 def about():
-  return render_template('about.html', title='About', menu='about')
+    return render_template('about.html', title='About', menu='about')
+
 
 @app.route('/login/', methods=['GET', 'POST'])
 def login():
@@ -159,128 +177,135 @@ def login():
     if form.validate_on_submit():
         user = User.query.filter_by(email=form.email.data).first()
         if user is not None and user.checkAndMigratePassword(form.password.data):
-          #db.session.commit()
-          login_user(user, remember=form.remember_me.data)
-          next_page = form.next.data
-          if not next_page or url_parse(next_page).netloc != '':
-              next_page = url_for('index')
-          return redirect(next_page)
+            # db.session.commit()
+            login_user(user, remember=form.remember_me.data)
+            next_page = form.next.data
+            if not next_page or url_parse(next_page).netloc != '':
+                next_page = url_for('index')
+            return redirect(next_page)
         else:
-          error = 'Invalid email and/or password'
+            error = 'Invalid email and/or password'
     return render_template('login.html', title='Sign In', form=form, error=error, menu='home')
+
 
 @app.route('/logout/')
 def logout():
     logout_user()
     return redirect(url_for('index'))
 
+
 @app.route('/register/', methods=['GET', 'POST'])
 def register():
     if current_user.is_authenticated:
-      return redirect(url_for('index'))
+        return redirect(url_for('index'))
     form = RegistrationForm()
     error = None
 
     if form.validate_on_submit():
-      user = User(name = form.name.data, email=form.email.data, country_code=form.country.data, user_type=form.organisation.data)
-      user.setPassword(form.password.data)
-      db.session.add(user)
-      db.session.commit()
-      flash('You are now registered and may log in')
-      return redirect(url_for('login'))
+        user = User(name=form.name.data, email=form.email.data, country_code=form.country.data,
+                    user_type=form.organisation.data)
+        user.setPassword(form.password.data)
+        db.session.add(user)
+        db.session.commit()
+        flash('You are now registered and may log in')
+        return redirect(url_for('login'))
     return render_template('register.html', title='Register', form=form, error=error, menu='home')
+
 
 @app.route('/library/')
 @app.route('/library/<int:page>/')
 @app.route('/scans/')
 @app.route('/scans/<int:page>/')
-def library(page = 1):
-  per_page = 100
-  sort = request.args.get("sort")
-  ontogenic_age = request.args.getlist("ontogenic_age")
-  geologic_age = request.args.getlist("geologic_age")
-  elements = request.args.getlist("elements")
-  taxonomy = request.args.getlist("taxonomy")
-  mine = 'mine' in request.args.keys()
-  search = request.args.get('q')
+def library(page=1):
+    per_page = 100
+    sort = request.args.get('sort')
+    ontogenic_age = request.args.getlist('ontogenic_age')
+    geologic_age = request.args.getlist('geologic_age')
+    elements = request.args.getlist('elements')
+    taxonomy = request.args.getlist('taxonomy')
+    mine = 'mine' in request.args.keys()
+    search = request.args.get('q')
 
-  scanConditions = [
-    Scan.published
-  ]
+    scanConditions = [
+        Scan.published
+    ]
 
-  if search:
-    searchQuery = '%{0}%'.format(search)
+    if search:
+        searchQuery = '%{0}%'.format(search)
 
-    textSearch = db.or_(
-      Scan.scientific_name.ilike(searchQuery),
-      Scan.alt_name.ilike(searchQuery),
-      Scan.specimen_id.ilike(searchQuery),
-      Scan.specimen_location.ilike(searchQuery),
-      Scan.description.ilike(searchQuery)
-    )
-
-    scanConditions.append(textSearch)
-
-  for searchTags in [ontogenic_age, geologic_age, elements]:
-    if len(searchTags) > 0:
-      scanConditions.append(
-        Scan.tags.any(
-          Tag.taxonomy.startswith(searchTags[0]) if len(searchTags) == 1 else db.or_(*[ Tag.taxonomy.startswith(term) for term in searchTags ])
+        textSearch = db.or_(
+            Scan.scientific_name.ilike(searchQuery),
+            Scan.alt_name.ilike(searchQuery),
+            Scan.specimen_id.ilike(searchQuery),
+            Scan.specimen_location.ilike(searchQuery),
+            Scan.description.ilike(searchQuery)
         )
-      )
 
-  if len(taxonomy) > 0:
-    scanConditions.append(Scan.taxonomy.any(Taxonomy.id.in_(taxonomy)))
+        scanConditions.append(textSearch)
 
-  if mine and current_user.is_authenticated:
-    scanConditions.append(Scan.author_id == current_user.id)
+    for searchTags in [ontogenic_age, geologic_age, elements]:
+        if len(searchTags) > 0:
+            scanConditions.append(
+                Scan.tags.any(
+                    Tag.taxonomy.startswith(searchTags[0]) if len(searchTags) == 1 else db.or_(
+                        *[Tag.taxonomy.startswith(term) for term in searchTags])
+                )
+            )
 
-  scanConditions = db.and_(*scanConditions)
+    if len(taxonomy) > 0:
+        scanConditions.append(Scan.taxonomy.any(Taxonomy.id.in_(taxonomy)))
 
-  # This is annoying... if we're sorting by name it's just sort,
-  # but if we're sorting by tag we need to group it all.
-  # Put it under the `groups` key so the view knows it needs to render differently
-  if(sort in ('geologic_age', 'ontogenic_age')):
-    results = [ (tag, tag.scans.filter(scanConditions).all()) for tag in Tag.query.filter_by(category=sort).all() ]
+    if mine and current_user.is_authenticated:
+        scanConditions.append(Scan.author_id == current_user.id)
 
-    data = {
-      'groups': [
-        {
-          'group': tag.name,
-          'items': [
-            s.serialize(full = False) for s in scans
-          ]
+    scanConditions = db.and_(*scanConditions)
+
+    # This is annoying... if we're sorting by name it's just sort,
+    # but if we're sorting by tag we need to group it all.
+    # Put it under the `groups` key so the view knows it needs to render differently
+    if (sort in ('geologic_age', 'ontogenic_age')):
+        results = [(tag, tag.scans.filter(scanConditions).all()) for tag in Tag.query.filter_by(category=sort).all()]
+
+        data = {
+            'groups': [
+                {
+                    'group': tag.name,
+                    'items': [
+                        s.serialize(full=False) for s in scans
+                    ]
+                }
+                for (tag, scans) in results if len(scans) > 0
+            ]
         }
-        for (tag, scans) in results if len(scans) > 0
-      ]
-    }
-  else:
-    query = Scan.scientific_name
+    else:
+        query = Scan.scientific_name
 
-    results = Scan.query.filter(scanConditions).order_by(query).paginate(page, per_page)
+        results = Scan.query.filter(scanConditions).order_by(query).paginate(page, per_page)
 
-    data = {
-      'scans': [ s.serialize(full = False) for s in results.items ],
-      'page': page,
-      'total_pages': math.ceil(results.total / per_page)
-    }
+        data = {
+            'scans': [s.serialize(full=False) for s in results.items],
+            'page': page,
+            'total_pages': math.ceil(results.total / per_page)
+        }
 
-  data['tags'] = Tag.tree()
-  data['tags']['taxonomy'] = Taxonomy.tree()
-  data['q'] = search
-  data['showMine'] = current_user.is_authenticated and current_user.isContributor()
+    data['tags'] = Tag.tree()
+    data['tags']['taxonomy'] = Taxonomy.tree()
+    data['q'] = search
+    data['showMine'] = current_user.is_authenticated and current_user.isContributor()
 
-  out = render_vue(data, title="Scans", menu='library')
+    out = render_vue(data, title='Scans', menu='library')
 
-  return out
+    return out
+
 
 @app.route('/feed')
 def feed():
-  """ Generate the RSS feed """
-  scans = Scan.query.filter(Scan.published).order_by(Scan.date_created)
-  resp = make_response(render_template('rss.xml', scans = scans))
-  resp.headers['Content-type'] = 'application/rss+xml'
-  return resp
+    """ Generate the RSS feed """
+    scans = Scan.query.filter(Scan.published).order_by(Scan.date_created)
+    resp = make_response(render_template('rss.xml', scans=scans))
+    resp.headers['Content-type'] = 'application/rss+xml'
+    return resp
+
 
 @app.route('/library/manage-uploads/', methods=['GET', 'POST'])
 @app.route('/library/manage-uploads/page/<int:page>/', methods=['GET', 'POST'])
@@ -288,190 +313,198 @@ def feed():
 @app.route('/scans/manage-uploads/page/<int:page>/', methods=['GET', 'POST'])
 @requiresContributor
 def manage_uploads(page=1):
-  """View a list of uploads with publish, edit, delete actions"""
+    """View a list of uploads with publish, edit, delete actions"""
 
-  # Process delete request
-  if request.method == 'POST':
-    scan_id = request.form.get('delete')
-    scan = Scan.query.get(scan_id)
-    ensureEditable(scan)
-    db.session.delete(scan)
-    db.session.commit()
-    return redirect(request.full_path)
+    # Process delete request
+    if request.method == 'POST':
+        scan_id = request.form.get('delete')
+        scan = Scan.query.get(scan_id)
+        ensureEditable(scan)
+        db.session.delete(scan)
+        db.session.commit()
+        return redirect(request.full_path)
 
-  # To publish, we have to submit to the ScanUploadForm endpoint,
-  # which requires a CSRF token. Construct the form to generate one.
-  ScanUploadForm()
+    # To publish, we have to submit to the ScanUploadForm endpoint,
+    # which requires a CSRF token. Construct the form to generate one.
+    ScanUploadForm()
 
-  per_page = 50
-  offset = (page - 1) * per_page
+    per_page = 50
+    offset = (page - 1) * per_page
 
-  startswith = request.args.get('char')
-  search = request.args.get('q')
+    startswith = request.args.get('char')
+    search = request.args.get('q')
 
-  query = Scan.query
+    query = Scan.query
 
-  if search:
-    searchQuery = '%{0}%'.format(search)
+    if search:
+        searchQuery = '%{0}%'.format(search)
 
-    query = query.filter(
-      db.or_(
-        Scan.scientific_name.ilike(searchQuery),
-        Scan.alt_name.ilike(searchQuery),
-        Scan.specimen_id.ilike(searchQuery),
-        Scan.specimen_location.ilike(searchQuery),
-        Scan.description.ilike(searchQuery)
-      )
-    )
+        query = query.filter(
+            db.or_(
+                Scan.scientific_name.ilike(searchQuery),
+                Scan.alt_name.ilike(searchQuery),
+                Scan.specimen_id.ilike(searchQuery),
+                Scan.specimen_location.ilike(searchQuery),
+                Scan.description.ilike(searchQuery)
+            )
+        )
 
-  if(startswith):
-    query = query.filter(Scan.scientific_name.startswith(startswith))
-  scans = query.paginate(page, per_page)
-  data = {
-    'scans': [ s.serialize() for s in scans.items if current_user.canEdit(s) ],
-    'page': page,
-    'total_pages': math.ceil(scans.total / per_page),
-    'csrf_token': g.csrf_token,
-    'q': search
-  }
-  return render_vue(data, title="Manage Uploads", menu="library")
+    if (startswith):
+        query = query.filter(Scan.scientific_name.startswith(startswith))
+    scans = query.paginate(page, per_page)
+    data = {
+        'scans': [s.serialize() for s in scans.items if current_user.canEdit(s)],
+        'page': page,
+        'total_pages': math.ceil(scans.total / per_page),
+        'csrf_token': g.csrf_token,
+        'q': search
+    }
+    return render_vue(data, title='Manage Uploads', menu='library')
+
 
 @app.route('/<scan:scan>/')
 def scan(scan):
-  if not scan.published and not (current_user.is_authenticated and current_user.canEdit(scan)):
-    raise NotFound()
-  data = hideScanFiles(scan.serialize())
+    if not scan.published and not (current_user.is_authenticated and current_user.canEdit(scan)):
+        raise NotFound()
+    data = hideScanFiles(scan.serialize())
 
-  return render_vue(data, title=scan.scientific_name, menu='library')
+    return render_vue(data, title=scan.scientific_name, menu='library')
+
 
 @app.route('/stills/<int:id>/', methods=['DELETE'])
 @login_required
 def delete_still(id):
-  """Url for deleting a still"""
-  attachment = ScanAttachment.query.filter_by(attachment_id=id).first()
-  return_to = url_for('library')
+    """Url for deleting a still"""
+    attachment = ScanAttachment.query.filter_by(attachment_id=id).first()
+    return_to = url_for('library')
 
-  if attachment:
-    ensureEditable(attachment)
-    return_to = url_for('edit_scan', scan=attachment.scan)
-    db.session.delete(attachment)
-    db.session.commit()
+    if attachment:
+        ensureEditable(attachment)
+        return_to = url_for('edit_scan', scan=attachment.scan)
+        db.session.delete(attachment)
+        db.session.commit()
 
-  # Use a 303 response to force browser to use GET for the next request
-  return redirect(return_to, code=303)
+    # Use a 303 response to force browser to use GET for the next request
+    return redirect(return_to, code=303)
+
 
 @app.route('/<scan:scan>/stills/')
 @login_required
 def scan_stills(scan):
-  """Return a zip file containing all of the stills attached to this scan"""
-  zip_buffer = io.BytesIO()
-  with ZipFile(zip_buffer, "w") as zip_file:
-    for still in scan.attachments:
-      zip_file.write(still.file.getAbsolutePath(), still.file.filename)
+    """Return a zip file containing all of the stills attached to this scan"""
+    zip_buffer = io.BytesIO()
+    with ZipFile(zip_buffer, 'w') as zip_file:
+        for still in scan.attachments:
+            zip_file.write(still.file.getAbsolutePath(), still.file.filename)
 
-  zip_buffer.seek(0)
-  filename = scan.url_slug + '_stills.zip'
+    zip_buffer.seek(0)
+    filename = scan.url_slug + '_stills.zip'
 
-  return send_file(zip_buffer, as_attachment=True, attachment_filename=filename)
+    return send_file(zip_buffer, as_attachment=True, attachment_filename=filename)
+
 
 @app.route('/scans/batch-upload/', methods=['GET', 'POST'])
 @requiresContributor
 def upload_multi():
-  files = []
-  if request.method == 'POST':
-    files = list(map(lambda f: f.filename ,request.files.getlist('source')))
-    app.logger.warning(files)
+    files = []
+    if request.method == 'POST':
+        files = list(map(lambda f: f.filename, request.files.getlist('source')))
+        app.logger.warning(files)
 
-  data = rpc_call('views.batchUpload', [{'inputName': 'source', 'files': files}])
+    data = rpc_call('views.batchUpload', [{'inputName': 'source', 'files': files}])
 
-  return render_content(
-    data.get('content'),
-    data.get('title'),
-    data.get('menu')
-  )
+    return render_content(
+        data.get('content'),
+        data.get('title'),
+        data.get('menu')
+    )
 
-@app.route('/files/', methods = ['POST'])
+
+@app.route('/files/', methods=['POST'])
 @requiresContributor
 def create_tmp_upload_file():
-  res = Response(status=201)
-  res.headers['Location'] = '/files/' + uploadStore.create()
-  return res
+    res = Response(status=201)
+    res.headers['Location'] = '/files/' + uploadStore.create()
+    return res
 
-@app.route('/files/<id>', methods = ['PATCH'])
+
+@app.route('/files/<id>', methods=['PATCH'])
 @requiresContributor
 def append_tmp_upload_file(id):
-  uploadStore.append(id, request.get_data())
-  return Response(status=200)
+    uploadStore.append(id, request.get_data())
+    return Response(status=200)
+
 
 @app.route('/<scan:scan>/edit', methods=['GET', 'POST'])
 @app.route('/library/create/', methods=['GET', 'POST'])
 @app.route('/scans/create/', methods=['GET', 'POST'])
 @requiresContributor
-def edit_scan(scan = None):
-  form = ScanUploadForm(obj=scan)
+def edit_scan(scan=None):
+    form = ScanUploadForm(obj=scan)
 
-  if scan:
-    ensureEditable(scan)
+    if scan:
+        ensureEditable(scan)
 
-    if not form.geologic_age.data:
-      form.geologic_age.data = scan.geologic_age
+        if not form.geologic_age.data:
+            form.geologic_age.data = scan.geologic_age
 
-    if not form.ontogenic_age.data:
-      form.ontogenic_age.data = scan.ontogenic_age
+        if not form.ontogenic_age.data:
+            form.ontogenic_age.data = scan.ontogenic_age
 
-    if not form.elements.data:
-      form.elements.data = scan.elements
+        if not form.elements.data:
+            form.elements.data = scan.elements
 
-  # Get the records for the currently selected publications
-  pubs = Publication.query.filter(Publication.author_id == current_user.id).all()
-  form.publications.choices = [(pub, pub.title) for pub in pubs]
+    # Get the records for the currently selected publications
+    pubs = Publication.query.filter(Publication.author_id == current_user.id).all()
+    form.publications.choices = [(pub, pub.title) for pub in pubs]
 
-  if request.method == 'POST':
-    if scan == None:
-      scan = scanStore.new(current_user.email)
+    if request.method == 'POST':
+        if scan == None:
+            scan = scanStore.new(current_user.email)
 
-    # Make sure whatever publications are selected pass validation
-    form.publications.choices = [(pub, pub.title) for pub in form.publications.data]
+        # Make sure whatever publications are selected pass validation
+        form.publications.choices = [(pub, pub.title) for pub in form.publications.data]
 
-    form_valid = True
+        form_valid = True
 
-    # If file data is a UUID string then it's been through the blob uploader, get actual file
-    # Todo: move this to uploadStore
-    if isinstance(form.file.data, str):
-      parts = form.file.data.split('/')
-      location = parts[0]
-      filename = parts[1] if len(parts) > 1 else None
+        # If file data is a UUID string then it's been through the blob uploader, get actual file
+        # Todo: move this to uploadStore
+        if isinstance(form.file.data, str):
+            parts = form.file.data.split('/')
+            location = parts[0]
+            filename = parts[1] if len(parts) > 1 else None
 
-      f = open(uploadStore.getFilepath(location), 'rb')
-      form.file.data = FileStorage(f, filename)
+            f = open(uploadStore.getFilepath(location), 'rb')
+            form.file.data = FileStorage(f, filename)
 
-    try:
-      url = scanStore.update(scan, form.file.data, form.data, form.attachments.data)
-      if form.file.data != None:
-        taskQueue.create_ctm(scan.id)
+        try:
+            url = scanStore.update(scan, form.file.data, form.data, form.attachments.data)
+            if form.file.data != None:
+                taskQueue.create_ctm(scan.id)
 
-      if form.published.data and form.validate():
-        scanStore.publish(url)
+            if form.published.data and form.validate():
+                scanStore.publish(url)
 
-    except ScanException as error:
-      form_valid = False
-      form.errors.append(error.message)
+        except ScanException as error:
+            form_valid = False
+            form.errors.append(error.message)
 
-    finally:
-      # Close the underlying stream if it's a file
-      if form.file.data != None:
-        form.file.data.close()
+        finally:
+            # Close the underlying stream if it's a file
+            if form.file.data != None:
+                form.file.data.close()
 
-    if form_valid and not request.args.get('noredirect'):
-      return redirect(request.args.get('redirect') or url_for('scan', scan=scan))
+        if form_valid and not request.args.get('noredirect'):
+            return redirect(request.args.get('redirect') or url_for('scan', scan=scan))
 
-  data = {
-      'form': form.serialize(),
-      'scan': scan.serialize() if scan else None,
-      'csrf_token': g.csrf_token
-  }
+    data = {
+        'form': form.serialize(),
+        'scan': scan.serialize() if scan else None,
+        'csrf_token': g.csrf_token
+    }
 
-  return render_vue(data, title='Edit' if scan else 'Upload New', menu='library')
+    return render_vue(data, title='Edit' if scan else 'Upload New', menu='library')
+
 
 @app.route('/publications/create/', methods=['GET', 'POST'])
 @app.route('/publication/<publication:publication>/edit', methods=['GET', 'POST'])
@@ -480,232 +513,242 @@ def edit_publication(publication=None):
     form = PublicationUploadForm(obj=publication)
 
     if publication:
-      ensureEditable(publication)
+        ensureEditable(publication)
 
     if form.validate_on_submit():
-      if not publication:
-        publication = Publication(
-          author_id = current_user.id,
-          url_slug = generate_slug(form.title.data)
-        )
-        db.session.add(publication)
-      publication.title = form.title.data
-      publication.pub_year = form.pub_year.data
-      publication.authors = form.authors.data
-      publication.journal = form.journal.data
-      publication.link = form.link.data
-      publication.abstract = form.abstract.data
-      publication.published = True
+        if not publication:
+            publication = Publication(
+                author_id=current_user.id,
+                url_slug=generate_slug(form.title.data)
+            )
+            db.session.add(publication)
+        publication.title = form.title.data
+        publication.pub_year = form.pub_year.data
+        publication.authors = form.authors.data
+        publication.journal = form.journal.data
+        publication.link = form.link.data
+        publication.abstract = form.abstract.data
+        publication.published = True
 
-      for file in form.files.data:
-        if file == '':
-          continue
-        f = File.fromUpload(file)
-        db.session.add(f)
-        publication.files.append(
-          Attachment(
-            file = f,
-            name = file.filename
-          )
-        )
+        for file in form.files.data:
+            if file == '':
+                continue
+            f = File.fromUpload(file)
+            db.session.add(f)
+            publication.files.append(
+                Attachment(
+                    file=f,
+                    name=file.filename
+                )
+            )
 
-      db.session.commit()
+        db.session.commit()
 
-      return redirect(url_for('edit_publication', publication=publication))
+        return redirect(url_for('edit_publication', publication=publication))
 
     data = {
-      'publication': publication.serialize() if publication else None,
-      'form': form.serialize(),
-      'csrf_token': g.csrf_token
+        'publication': publication.serialize() if publication else None,
+        'form': form.serialize(),
+        'csrf_token': g.csrf_token
     }
 
     return render_vue(data, title='Edit' if publication else 'Create', menu='publications')
 
+
 @app.route('/remove-pub-file/<int:id>', methods=['DELETE'])
 @requiresContributor
 def delete_pub_file(id):
-  """Url for deleting a file"""
-  attachment = PublicationFile.query.filter_by(attachment_id=id).first()
-  return_to = url_for('publications')
+    """Url for deleting a file"""
+    attachment = PublicationFile.query.filter_by(attachment_id=id).first()
+    return_to = url_for('publications')
 
-  if attachment:
-    ensureEditable(attachment)
-    return_to = url_for('edit_publication', publication=attachment.publication)
-    db.session.delete(attachment)
-    db.session.commit()
+    if attachment:
+        ensureEditable(attachment)
+        return_to = url_for('edit_publication', publication=attachment.publication)
+        db.session.delete(attachment)
+        db.session.commit()
 
-  # Use a 303 response to force browser to use GET for the next request
-  return redirect(return_to, code=303)
+    # Use a 303 response to force browser to use GET for the next request
+    return redirect(return_to, code=303)
+
 
 @app.route('/publications/')
 @app.route('/publications/page/<int:page>/')
-def publications(page = 1):
-  per_page = 100
+def publications(page=1):
+    per_page = 100
 
-  search = request.args.get('q')
-  mine = 'mine' in request.args.keys()
+    search = request.args.get('q')
+    mine = 'mine' in request.args.keys()
 
-  if search:
-    searchQuery = '%{0}%'.format(search)
+    if search:
+        searchQuery = '%{0}%'.format(search)
 
-    query = Publication.query.filter(
-      db.or_(
-        Publication.title.ilike(searchQuery),
-        Publication.authors.ilike(searchQuery)
-      )
-    )
-  else:
-    query = Publication.query
+        query = Publication.query.filter(
+            db.or_(
+                Publication.title.ilike(searchQuery),
+                Publication.authors.ilike(searchQuery)
+            )
+        )
+    else:
+        query = Publication.query
 
-  if mine and current_user.is_authenticated:
-    query = query.filter(Publication.author_id == current_user.id)
+    if mine and current_user.is_authenticated:
+        query = query.filter(Publication.author_id == current_user.id)
 
-  query = query.order_by(Publication.pub_year.desc())
+    query = query.order_by(Publication.pub_year.desc())
 
-  pubs = query.filter_by(published = True).paginate(page, per_page)
+    pubs = query.filter_by(published=True).paginate(page, per_page)
 
-  data = {
-    'publications': [ pub.serialize() for pub in pubs.items ],
-    'page': page,
-    'total_pages': math.ceil(pubs.total / per_page),
-    'q': search
-  }
+    data = {
+        'publications': [pub.serialize() for pub in pubs.items],
+        'page': page,
+        'total_pages': math.ceil(pubs.total / per_page),
+        'q': search
+    }
 
-  return render_vue(data, title='Publications', menu='publications')
+    return render_vue(data, title='Publications', menu='publications')
+
 
 @app.route('/publications/manage-publications/', methods=['GET', 'POST'])
 @app.route('/publications/manage-publications/page/<int:page>/', methods=['GET', 'POST'])
 @requiresContributor
 def manage_publications(page=1):
-  """View a list of publications with publish, edit, delete actions"""
+    """View a list of publications with publish, edit, delete actions"""
 
-  # Process delete request
-  if request.method == 'POST':
-    action = request.form.get('action')
-    publication_id = request.form.get('id')
-    if publication_id:
-      publication = Publication.query.get(publication_id)
-      ensureEditable(publication)
+    # Process delete request
+    if request.method == 'POST':
+        action = request.form.get('action')
+        publication_id = request.form.get('id')
+        if publication_id:
+            publication = Publication.query.get(publication_id)
+            ensureEditable(publication)
 
-      if action == 'delete':
-        db.session.delete(publication)
-        db.session.commit()
-      elif action == 'publish':
-        publication.published = True
-        db.session.commit()
-      elif action == 'unpublish':
-        publication.published = False
-        db.session.commit()
-    return redirect(request.full_path)
+            if action == 'delete':
+                db.session.delete(publication)
+                db.session.commit()
+            elif action == 'publish':
+                publication.published = True
+                db.session.commit()
+            elif action == 'unpublish':
+                publication.published = False
+                db.session.commit()
+        return redirect(request.full_path)
 
-  per_page = 50
-  offset = (page - 1) * per_page
+    per_page = 50
+    offset = (page - 1) * per_page
 
-  pub_year = request.args.get('pub_year')
-  search = request.args.get('q')
+    pub_year = request.args.get('pub_year')
+    search = request.args.get('q')
 
-  query = Publication.query
+    query = Publication.query
 
-  if search:
-    searchQuery = '%{0}%'.format(search)
+    if search:
+        searchQuery = '%{0}%'.format(search)
 
-    query = query.filter(
-      db.or_(
-        Publication.title.ilike(searchQuery),
-        Publication.authors.ilike(searchQuery)
-      )
-    )
-  if(pub_year):
-    query = query.filter_by(pub_year = pub_year)
-  publications = query.order_by(Publication.pub_year.desc()).paginate(page, per_page)
-  data = {
-    'publications': [ pub.serialize() for pub in publications.items if current_user.canEdit(pub) ],
-    'page': page,
-    'total_pages': math.ceil(publications.total / per_page),
-    'years': [ y[0] for y in db.session.query(Publication.pub_year).order_by(Publication.pub_year.desc()).distinct().all() ],
-    'q': search
-  }
-  return render_vue(data, title="Manage Publications", menu="publications")
+        query = query.filter(
+            db.or_(
+                Publication.title.ilike(searchQuery),
+                Publication.authors.ilike(searchQuery)
+            )
+        )
+    if (pub_year):
+        query = query.filter_by(pub_year=pub_year)
+    publications = query.order_by(Publication.pub_year.desc()).paginate(page, per_page)
+    data = {
+        'publications': [pub.serialize() for pub in publications.items if current_user.canEdit(pub)],
+        'page': page,
+        'total_pages': math.ceil(publications.total / per_page),
+        'years': [y[0] for y in
+                  db.session.query(Publication.pub_year).order_by(Publication.pub_year.desc()).distinct().all()],
+        'q': search
+    }
+    return render_vue(data, title='Manage Publications', menu='publications')
+
 
 @app.route('/publication/<publication:publication>/')
 def publication(publication):
-  if not publication.published and not (current_user.is_authenticated and current_user.canEdit(publication)):
-    raise NotFound()
-  return render_vue(publication.serialize(), title=publication.title, menu='publications')
+    if not publication.published and not (current_user.is_authenticated and current_user.canEdit(publication)):
+        raise NotFound()
+    return render_vue(publication.serialize(), title=publication.title, menu='publications')
+
 
 @app.route('/contribute/', methods=['GET', 'POST'])
 def contribute():
-  if current_user.is_authenticated and request.method == 'POST':
-    message = request.form.get('message')
+    if current_user.is_authenticated and request.method == 'POST':
+        message = request.form.get('message')
 
-    body = current_user.name + " would like to become a contributor to Phenome10k:\n\n"
-    html = current_user.name + " would like to become a contributor to Phenome10k:<br><br>"
+        body = current_user.name + ' would like to become a contributor to Phenome10k:\n\n'
+        html = current_user.name + ' would like to become a contributor to Phenome10k:<br><br>'
 
-    if message:
-      body += '"' + message + '"\n\n'
-      html += '<blockquote>"' + message + '"</blockquote><br><br>'
+        if message:
+            body += '"' + message + '"\n\n'
+            html += '<blockquote>"' + message + '"</blockquote><br><br>'
 
-    profileLink = url_for('users', id=current_user.id, _external=True)
+        profileLink = url_for('users', id=current_user.id, _external=True)
 
-    body += (
-      "To approve their request, use the following link:\n" + profileLink
-    )
-    html += "<a href='" + profileLink + "'>Approve this request</a>"
+        body += (
+                'To approve their request, use the following link:\n' + profileLink
+        )
+        html += '<a href="' + profileLink + '">Approve this request</a>'
 
-    mail.send(Message(
-      recipients = [app.config['ADMIN_EMAIL']],
-      reply_to = (current_user.name, current_user.email),
-      subject = current_user.name + " has requested to become a Phenome10k contributor",
-      body = body,
-      html = html
-    ))
-  return render_template('contribute.html', title='Contributing', menu='home')
+        mail.send(Message(
+            recipients=[app.config['ADMIN_EMAIL']],
+            reply_to=(current_user.name, current_user.email),
+            subject=current_user.name + ' has requested to become a Phenome10k contributor',
+            body=body,
+            html=html
+        ))
+    return render_template('contribute.html', title='Contributing', menu='home')
+
 
 @app.route('/users', methods=['GET', 'POST'])
 @requiresAdmin
 def users():
-  error = ''
+    error = ''
 
-  if request.method == 'POST':
-    id = request.form.get('id')
-    user = User.query.get(id)
+    if request.method == 'POST':
+        id = request.form.get('id')
+        user = User.query.get(id)
 
-    if user:
-      # Todo: Validation and errors
-      user.role = request.form.get('role')
-      db.session.commit()
-      return redirect(url_for('users'))
-    else:
-      error = 'No user was found for id ' + id
+        if user:
+            # Todo: Validation and errors
+            user.role = request.form.get('role')
+            db.session.commit()
+            return redirect(url_for('users'))
+        else:
+            error = 'No user was found for id ' + id
 
-  query = User.query
-  id = request.args.get('id')
+    query = User.query
+    id = request.args.get('id')
 
-  if id:
-    query = query.filter_by(id=id)
+    if id:
+        query = query.filter_by(id=id)
 
-  users = [ user.serialize() for user in query.all() ]
-  data = { 'users': users, 'error': error }
+    users = [user.serialize() for user in query.all()]
+    data = {'users': users, 'error': error}
 
-  return render_vue(data, title = 'Users', menu = 'users')
+    return render_vue(data, title='Users', menu='users')
 
 
-def render_vue(data, title, menu = None):
-  # Ensure browser cache doesn't confuse html and json docs at the same url
-  # response.headers['Vary'] = 'Content-Type'
+def render_vue(data, title, menu=None):
+    # Ensure browser cache doesn't confuse html and json docs at the same url
+    # response.headers['Vary'] = 'Content-Type'
 
-  if request.accept_mimetypes.accept_html:
-    return render_content(content=vue(data), title=title, menu=menu)
-  return jsonify(data)
+    if request.accept_mimetypes.accept_html:
+        return render_content(content=vue(data), title=title, menu=menu)
+    return jsonify(data)
+
 
 def render_content(content, title, menu=None):
-  return render_template('base.html', content=content, title=title, menu=menu)
+    return render_template('base.html', content=content, title=title, menu=menu)
+
 
 # This is for server-side rendering a view in vue
 # pass the url path and an object to be provided as the defaultData property to the vue model
-def vue(defaultData = None):
-  path = request.full_path
-  return rpc_call('render', [path, defaultData])
+def vue(defaultData=None):
+    path = request.full_path
+    return rpc_call('render', [path, defaultData])
+
 
 def rpc_call(method, data):
-  return rpc.rpc(app.config['RPC_HOST'], method, data)
+    return rpc.rpc(app.config['RPC_HOST'], method, data)

--- a/app/routes.py
+++ b/app/routes.py
@@ -149,7 +149,7 @@ def send_uploads(path):
         except OSError:
             raise BadRequest()
 
-        if (width >= im.width):
+        if width >= im.width:
             return send_from_directory(app.config['UPLOAD_DIRECTORY'], path)
 
         try:
@@ -263,7 +263,7 @@ def library(page=1):
     # This is annoying... if we're sorting by name it's just sort,
     # but if we're sorting by tag we need to group it all.
     # Put it under the `groups` key so the view knows it needs to render differently
-    if (sort in ('geologic_age', 'ontogenic_age')):
+    if sort in ('geologic_age', 'ontogenic_age'):
         results = [(tag, tag.scans.filter(scan_conditions).all()) for tag in Tag.query.filter_by(category=sort).all()]
 
         data = {
@@ -350,7 +350,7 @@ def manage_uploads(page=1):
             )
         )
 
-    if (startswith):
+    if startswith:
         query = query.filter(Scan.scientific_name.startswith(startswith))
     scans = query.paginate(page, per_page)
     data = {
@@ -653,7 +653,7 @@ def manage_publications(page=1):
                 Publication.authors.ilike(search_query)
             )
         )
-    if (pub_year):
+    if pub_year:
         query = query.filter_by(pub_year=pub_year)
     publications = query.order_by(Publication.pub_year.desc()).paginate(page, per_page)
     data = {

--- a/app/routes.py
+++ b/app/routes.py
@@ -372,11 +372,11 @@ def scan(scan_object):
     return render_vue(data, title=scan_object.scientific_name, menu='library')
 
 
-@app.route('/stills/<int:id>/', methods=['DELETE'])
+@app.route('/stills/<int:still_id>/', methods=['DELETE'])
 @login_required
-def delete_still(id):
+def delete_still(still_id):
     """Url for deleting a still"""
-    attachment = ScanAttachment.query.filter_by(attachment_id=id).first()
+    attachment = ScanAttachment.query.filter_by(attachment_id=still_id).first()
     return_to = url_for('library')
 
     if attachment:
@@ -429,10 +429,10 @@ def create_tmp_upload_file():
     return res
 
 
-@app.route('/files/<id>', methods=['PATCH'])
+@app.route('/files/<file_id>', methods=['PATCH'])
 @requires_contributor
-def append_tmp_upload_file(id):
-    uploadStore.append(id, request.get_data())
+def append_tmp_upload_file(file_id):
+    uploadStore.append(file_id, request.get_data())
     return Response(status=200)
 
 
@@ -556,11 +556,11 @@ def edit_publication(pub_object=None):
     return render_vue(data, title='Edit' if pub_object else 'Create', menu='publications')
 
 
-@app.route('/remove-pub-file/<int:id>', methods=['DELETE'])
+@app.route('/remove-pub-file/<int:attach_id>', methods=['DELETE'])
 @requires_contributor
-def delete_pub_file(id):
+def delete_pub_file(attach_id):
     """Url for deleting a file"""
-    attachment = PublicationFile.query.filter_by(attachment_id=id).first()
+    attachment = PublicationFile.query.filter_by(attachment_id=attach_id).first()
     return_to = url_for('publications')
 
     if attachment:
@@ -707,8 +707,8 @@ def users():
     error = ''
 
     if request.method == 'POST':
-        id = request.form.get('id')
-        user = User.query.get(id)
+        user_id = request.form.get('id')
+        user = User.query.get(user_id)
 
         if user:
             # Todo: Validation and errors
@@ -716,13 +716,13 @@ def users():
             db.session.commit()
             return redirect(url_for('users'))
         else:
-            error = 'No user was found for id ' + id
+            error = 'No user was found for id ' + user_id
 
     query = User.query
-    id = request.args.get('id')
+    user_id = request.args.get('id')
 
-    if id:
-        query = query.filter_by(id=id)
+    if user_id:
+        query = query.filter_by(id=user_id)
 
     users = [user.serialize() for user in query.all()]
     data = {'users': users, 'error': error}

--- a/app/routes.py
+++ b/app/routes.py
@@ -475,7 +475,7 @@ def edit_scan(scan=None):
             location = parts[0]
             filename = parts[1] if len(parts) > 1 else None
 
-            f = open(uploadStore.getFilepath(location), 'rb')
+            f = open(uploadStore.get_filepath(location), 'rb')
             form.file.data = FileStorage(f, filename)
 
         try:

--- a/app/routes.py
+++ b/app/routes.py
@@ -688,9 +688,7 @@ def contribute():
 
         profileLink = url_for('users', id=current_user.id, _external=True)
 
-        body += (
-                'To approve their request, use the following link:\n' + profileLink
-        )
+        body += ('To approve their request, use the following link:\n' + profileLink)
         html += '<a href="' + profileLink + '">Approve this request</a>'
 
         mail.send(Message(

--- a/app/routes.py
+++ b/app/routes.py
@@ -6,7 +6,7 @@ from zipfile import ZipFile
 
 from PIL import Image
 from flask import request, render_template, redirect, url_for, flash, send_from_directory, jsonify, g, Response, \
-  send_file, make_response
+    send_file, make_response
 from flask.helpers import safe_join
 from flask_login import current_user, login_user, login_required, logout_user
 from flask_mail import Message
@@ -51,7 +51,7 @@ class SlugConverter(BaseConverter):
 
     def to_python(self, slug):
         model = self.model.findBySlug(slug)
-        if model == None:
+        if model is None:
             raise ValidationError
         return model
 
@@ -124,7 +124,7 @@ def send_uploads(path):
     """Route for downloading an uploaded file. Images may be resized using the `w` parameter to specify width"""
     width = request.args.get('w')
 
-    if width == None:
+    if width is None:
         return send_from_directory(app.config['UPLOAD_DIRECTORY'], path)
 
     thumbnail_file = path + '-' + width + '.png'
@@ -459,7 +459,7 @@ def edit_scan(scan=None):
     form.publications.choices = [(pub, pub.title) for pub in pubs]
 
     if request.method == 'POST':
-        if scan == None:
+        if scan is None:
             scan = scanStore.new(current_user.email)
 
         # Make sure whatever publications are selected pass validation
@@ -479,7 +479,7 @@ def edit_scan(scan=None):
 
         try:
             url = scanStore.update(scan, form.file.data, form.data, form.attachments.data)
-            if form.file.data != None:
+            if form.file.data is not None:
                 taskQueue.create_ctm(scan.id)
 
             if form.published.data and form.validate():
@@ -491,7 +491,7 @@ def edit_scan(scan=None):
 
         finally:
             # Close the underlying stream if it's a file
-            if form.file.data != None:
+            if form.file.data is not None:
                 form.file.data.close()
 
         if form_valid and not request.args.get('noredirect'):

--- a/app/routes.py
+++ b/app/routes.py
@@ -329,6 +329,7 @@ def manage_uploads(page=1):
     ScanUploadForm()
 
     per_page = 50
+    # FIXME offset is not used
     offset = (page - 1) * per_page
 
     startswith = request.args.get('char')
@@ -635,6 +636,7 @@ def manage_publications(page=1):
         return redirect(request.full_path)
 
     per_page = 50
+    # FIXME offset is not used
     offset = (page - 1) * per_page
 
     pub_year = request.args.get('pub_year')

--- a/app/routes.py
+++ b/app/routes.py
@@ -494,7 +494,7 @@ def edit_scan(scan_object=None):
                 form.file.data.close()
 
         if form_valid and not request.args.get('noredirect'):
-            return redirect(request.args.get('redirect') or url_for('scan', scan=scan_object))
+            return redirect(request.args.get('redirect') or url_for('scan', scan_object=scan_object))
 
     data = {
         'form': form.serialize(),
@@ -543,7 +543,7 @@ def edit_publication(pub_object=None):
 
         db.session.commit()
 
-        return redirect(url_for('edit_publication', publication=pub_object))
+        return redirect(url_for('edit_publication', pub_object=pub_object))
 
     data = {
         'publication': pub_object.serialize() if pub_object else None,
@@ -563,7 +563,7 @@ def delete_pub_file(attach_id):
 
     if attachment:
         ensure_editable(attachment)
-        return_to = url_for('edit_publication', publication=attachment.publication)
+        return_to = url_for('edit_publication', pub_object=attachment.publication)
         db.session.delete(attachment)
         db.session.commit()
 
@@ -684,7 +684,7 @@ def contribute():
             body += '"' + message + '"\n\n'
             html += '<blockquote>"' + message + '"</blockquote><br><br>'
 
-        profile_link = url_for('users', id=current_user.id, _external=True)
+        profile_link = url_for('users', user_id=current_user.id, _external=True)
 
         body += ('To approve their request, use the following link:\n' + profile_link)
         html += '<a href="' + profile_link + '">Approve this request</a>'

--- a/app/rpc.py
+++ b/app/rpc.py
@@ -1,14 +1,14 @@
 import requests
-import json
+
 
 def rpc(url, method, params):
-	payload = {
-			"method": method,
-			"params": params,
-			"jsonrpc": "2.0",
-			"id": 0,
-	}
-	response = requests.post(url, json=payload).json()
-	if("error" in response):
-		raise Exception(response["error"]["message"])
-	return response["result"]
+    payload = {
+        'method': method,
+        'params': params,
+        'jsonrpc': '2.0',
+        'id': 0,
+    }
+    response = requests.post(url, json=payload).json()
+    if ('error' in response):
+        raise Exception(response['error']['message'])
+    return response['result']

--- a/app/rpc.py
+++ b/app/rpc.py
@@ -9,6 +9,6 @@ def rpc(url, method, params):
         'id': 0,
     }
     response = requests.post(url, json=payload).json()
-    if ('error' in response):
+    if 'error' in response:
         raise Exception(response['error']['message'])
     return response['result']

--- a/app/tasks/client.py
+++ b/app/tasks/client.py
@@ -1,6 +1,6 @@
 class TaskQueue:
-    def __init__(self, QueueModel):
-        self.queue = QueueModel
+    def __init__(self, queue_model):
+        self.queue = queue_model
 
     def create_ctm(self, scan_slug):
         self.queue.add('create_ctm', scan_slug)

--- a/app/tasks/client.py
+++ b/app/tasks/client.py
@@ -1,6 +1,6 @@
 class TaskQueue:
-	def __init__(self, QueueModel):
-		self.queue = QueueModel
+    def __init__(self, QueueModel):
+        self.queue = QueueModel
 
-	def create_ctm(self, scan_slug):
-		self.queue.add('create_ctm', scan_slug)
+    def create_ctm(self, scan_slug):
+        self.queue.add('create_ctm', scan_slug)

--- a/app/tasks/server.py
+++ b/app/tasks/server.py
@@ -1,9 +1,9 @@
 class TaskExecutor:
-    def __init__(self, QueueModel, scanStore):
-        self.queue = QueueModel
-        self.scanStore = scanStore
+    def __init__(self, queue_model, scan_store):
+        self.queue = queue_model
+        self.scan_store = scan_store
         self.methods = {
-            'create_ctm': lambda slug: scanStore.create_ctm(slug)
+            'create_ctm': lambda slug: scan_store.create_ctm(slug)
         }
 
     def execute(self, task):

--- a/app/tasks/server.py
+++ b/app/tasks/server.py
@@ -1,34 +1,33 @@
 class TaskExecutor:
-	def __init__(self, QueueModel, scanStore):
-		self.queue = QueueModel
-		self.scanStore = scanStore
-		self.methods = {
-			"create_ctm": lambda slug: scanStore.create_ctm(slug)
-		}
+    def __init__(self, QueueModel, scanStore):
+        self.queue = QueueModel
+        self.scanStore = scanStore
+        self.methods = {
+            'create_ctm': lambda slug: scanStore.create_ctm(slug)
+        }
 
-	def execute(self, task):
-		(method, args) = task
-		function = self.methods.get(method, None)
+    def execute(self, task):
+        (method, args) = task
+        function = self.methods.get(method, None)
 
-		print(method, args)
-		if function == None:
-			print("No function for method " + method)
-		else:
-			function(*args)
+        print(method, args)
+        if function == None:
+            print('No function for method ' + method)
+        else:
+            function(*args)
 
+    def next(self):
+        task = self.queue.get()
+        if task == None:
+            return False
 
-	def next(self):
-		task = self.queue.get()
-		if task == None:
-			return False
+        self.execute(task)
 
-		self.execute(task)
+        return True
 
-		return True
-
-	def run(self):
-		for task in self.queue.read():
-			try:
-				self.execute(task)
-			except Exception as err:
-				print(err)
+    def run(self):
+        for task in self.queue.read():
+            try:
+                self.execute(task)
+            except Exception as err:
+                print(err)

--- a/app/tasks/server.py
+++ b/app/tasks/server.py
@@ -11,14 +11,14 @@ class TaskExecutor:
         function = self.methods.get(method, None)
 
         print(method, args)
-        if function == None:
+        if function is None:
             print('No function for method ' + method)
         else:
             function(*args)
 
     def next(self):
         task = self.queue.get()
-        if task == None:
+        if task is None:
             return False
 
         self.execute(task)

--- a/app/tasks/tests/test_client.py
+++ b/app/tasks/tests/test_client.py
@@ -1,17 +1,18 @@
-import pytest
 from ..client import TaskQueue
 
-class MockQueue:
-  def __init__(self):
-    self.queue = []
 
-  def add(self, task, *args):
-    self.queue.append((task, args))
+class MockQueue:
+    def __init__(self):
+        self.queue = []
+
+    def add(self, task, *args):
+        self.queue.append((task, args))
+
 
 def test_create_ctm():
-  q = MockQueue()
-  client = TaskQueue(q)
+    q = MockQueue()
+    client = TaskQueue(q)
 
-  client.create_ctm('slug')
+    client.create_ctm('slug')
 
-  assert q.queue == [('create_ctm', ('slug',))]
+    assert q.queue == [('create_ctm', ('slug',))]

--- a/app/tasks/tests/test_server.py
+++ b/app/tasks/tests/test_server.py
@@ -2,8 +2,8 @@ from ..server import TaskExecutor
 
 
 class MockQueue:
-    def __init__(self, items=[]):
-        self.queue = items
+    def __init__(self, items=None):
+        self.queue = items or []
 
     def read(self):
         for item in self.queue:

--- a/app/tasks/tests/test_server.py
+++ b/app/tasks/tests/test_server.py
@@ -1,33 +1,35 @@
-import pytest
 from ..server import TaskExecutor
 
-class MockQueue:
-  def __init__(self, items=[]):
-    self.queue = items
 
-  def read(self):
-    for item in self.queue:
-      yield item
+class MockQueue:
+    def __init__(self, items=[]):
+        self.queue = items
+
+    def read(self):
+        for item in self.queue:
+            yield item
+
 
 class MockScanStore:
-  def __init__(self):
-    self.calls = []
+    def __init__(self):
+        self.calls = []
 
-  def create_ctm(self, slug):
-    self.calls.append(slug)
+    def create_ctm(self, slug):
+        self.calls.append(slug)
 
-    if(slug=='3'):
-      raise Exception("I don't like the number three.")
+        if (slug == '3'):
+            raise Exception("I don't like the number three.")
+
 
 def test_create_ctm():
-  s = MockScanStore()
-  q = MockQueue([
-    ('create_ctm', ('1',)),
-    ('invalid', ('2',)),
-    ('create_ctm', ('3',)),
-  ])
+    s = MockScanStore()
+    q = MockQueue([
+        ('create_ctm', ('1',)),
+        ('invalid', ('2',)),
+        ('create_ctm', ('3',)),
+    ])
 
-  server = TaskExecutor(q, s)
-  server.run()
+    server = TaskExecutor(q, s)
+    server.run()
 
-  assert s.calls == ['1', '3']
+    assert s.calls == ['1', '3']

--- a/app/tasks/tests/test_server.py
+++ b/app/tasks/tests/test_server.py
@@ -17,7 +17,7 @@ class MockScanStore:
     def create_ctm(self, slug):
         self.calls.append(slug)
 
-        if (slug == '3'):
+        if slug == '3':
             raise Exception("I don't like the number three.")
 
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -23,18 +23,18 @@
       <li><a class="Nav__item{{ ' Nav__item--selected' if menu == 'about' else '' }}" href="{{ url_for('about') }}">About</a></li>
       <li><a class="Nav__item{{ ' Nav__item--selected' if menu == 'library' else '' }}" href="{{ url_for('library') }}">Scans</a></li>
       <li><a class="Nav__item{{ ' Nav__item--selected' if menu == 'publications' else '' }}" href="{{ url_for('publications') }}">Publications</a></li>
-      {% if not current_user.is_anonymous and current_user.isAdmin() %}
+      {% if not current_user.is_anonymous and current_user.is_admin() %}
       <li><a class="Nav__item{{ ' Nav__item--selected' if menu == 'users' else '' }}" href="{{ url_for('users') }}">Users</a></li>
       {% endif %}
     </ul>
   </nav>
   {% if not current_user.is_anonymous %}
   <ul class="Base__subnav Nav__list">
-    {% if menu == 'library' and current_user.isContributor()  %}
+    {% if menu == 'library' and current_user.is_contributor()  %}
       <li><a href="{{ url_for('library', mine='') }}">View My Uploads</a></li>
       <li><a href="{{ url_for('manage_uploads') }}">Manage Uploads</a></li>
       <li><a href="{{ url_for('edit_scan') }}">Add New</a></li>
-    {% elif menu == 'publications' and current_user.isContributor()  %}
+    {% elif menu == 'publications' and current_user.is_contributor()  %}
       <li><a href="{{ url_for('publications') }}">View all pubs</a></li>
       <li><a href="{{ url_for('publications', mine='') }}">View my pubs</a></li>
       <li><a href="{{ url_for('manage_publications') }}">Manage Pubs</a></li>

--- a/app/templates/contribute.html
+++ b/app/templates/contribute.html
@@ -5,7 +5,7 @@
 <link rel="stylesheet" href="/static/contribute.css">
 
 <div class="Contribute">
-  {% if not current_user.is_authenticated or not current_user.isContributor() %}
+  {% if not current_user.is_authenticated or not current_user.is_contributor() %}
   <h1>Become a contributor to Phenome10K!</h1>
 
   <p>Phenome10K is a free resource for 3-D images of all types, including CT and surface scans. If you have 3-D images of biological or palaeontological specimens, please consider sharing your data via Phenome10K. You can link all images to associated publications, and we request all users to cite the appropriate primary publication if using any data from this database. Please obtain permission from the relevant institutions holding any imaged specimens before publishing them on Phenome10K.org. Unless otherwise noted, data on Phenome10K.org is licensed under a Creative Commons Attribution-NonCommercial 4.0 International License. </p>

--- a/app/templates/rss.xml
+++ b/app/templates/rss.xml
@@ -11,7 +11,7 @@
     {% for scan in scans %}
     <item>
       <title>{{ scan.scientific_name }}</title>
-      <link>{{ url_for('scan', scan=scan) }}</link>
+      <link>{{ url_for('scan', scan_object=scan_object) }}</link>
       <pubDate>{{ scan.date_created }}</pubDate>
       <guid isPermaLink="false">http://phenome10k.org/?p={{ scan.id }}</guid>
       <description>{{ scan.description }}</description>

--- a/app/tests/test_models.py
+++ b/app/tests/test_models.py
@@ -1,31 +1,33 @@
 import pytest
+
 from app import app, db, models
+
 
 @pytest.fixture
 def db_models():
-  """Create a client to test requests to the app"""
-  app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
-  app.testing = True
+    """Create a client to test requests to the app"""
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.testing = True
 
-  # Set up the app context
-  with app.app_context():
-    # Create database and admin user
-    db.create_all()
+    # Set up the app context
+    with app.app_context():
+        # Create database and admin user
+        db.create_all()
 
-    # Create test client and run the tests
-    yield models
+        # Create test client and run the tests
+        yield models
 
-  # Empty database for next test
-  db.drop_all()
+    # Empty database for next test
+    db.drop_all()
 
 
 def test_queue(db_models):
-  Queue = db_models.Queue
+    Queue = db_models.Queue
 
-  Queue.add('method_name', 'arg1', 2)
-  Queue.add('method_name2', 'another arg')
+    Queue.add('method_name', 'arg1', 2)
+    Queue.add('method_name2', 'another arg')
 
-  iterator = Queue.read()
+    iterator = Queue.read()
 
-  assert iterator.__next__() == ('method_name', ['arg1', 2])
-  assert iterator.__next__() == ('method_name2', ['another arg', ])
+    assert iterator.__next__() == ('method_name', ['arg1', 2])
+    assert iterator.__next__() == ('method_name2', ['another arg', ])

--- a/app/tests/test_models.py
+++ b/app/tests/test_models.py
@@ -22,12 +22,12 @@ def db_models():
 
 
 def test_queue(db_models):
-    Queue = db_models.Queue
+    queue = db_models.Queue
 
-    Queue.add('method_name', 'arg1', 2)
-    Queue.add('method_name2', 'another arg')
+    queue.add('method_name', 'arg1', 2)
+    queue.add('method_name2', 'another arg')
 
-    iterator = Queue.read()
+    iterator = queue.read()
 
     assert iterator.__next__() == ('method_name', ['arg1', 2])
     assert iterator.__next__() == ('method_name2', ['another arg', ])

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -1,5 +1,7 @@
 import json
 import re
+import io
+import time
 
 import pytest
 
@@ -114,7 +116,6 @@ def test_stl_upload(client, tmpdir, admin):
     app.config['UPLOAD_DIRECTORY'] = tmpdir
     app.config['MODEL_DIRECTORY'] = tmpdir
 
-    import io, time
     upload_file = (io.BytesIO(b'random data'), 'test_file.stl')
     data = {'file': upload_file, 'csrf_token': csrf_token(client)}
     response = client.post(
@@ -143,7 +144,6 @@ def test_zip_upload(client, tmpdir, admin):
     app.config['UPLOAD_DIRECTORY'] = tmpdir
     app.config['MODEL_DIRECTORY'] = tmpdir
 
-    import io, time
     from pathlib import Path
 
     horse = io.BytesIO(Path(__file__).parent.parent.parent.joinpath('fixtures/Horse.zip').read_bytes())

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -1,47 +1,52 @@
-import pytest
-import re
 import json
-from flask import Flask
-from flask_sqlalchemy import SQLAlchemy
+import re
+
+import pytest
+
 from app import app, db, models
 
+
 def csrf_token(client):
-  """Generate a csrf token"""
-  from flask import g
+    """Generate a csrf token"""
+    from flask import g
 
-  # If the front page has been loaded once, the token will be in `g`
-  if csrf_token in g:
-    return g.csrf_token
+    # If the front page has been loaded once, the token will be in `g`
+    if csrf_token in g:
+        return g.csrf_token
 
-  # Otherwise, do a request for the login page and get it from regex
-  # Don't think there's a more straight forward way of doing this sadly
-  login_page = client.get('/login')
-  m = re.search(r'<input id="csrf_token" name="csrf_token" type="hidden" value="([^"]+)">', login_page.data.decode('utf-8'))
-  csrf = m[1]
+    # Otherwise, do a request for the login page and get it from regex
+    # Don't think there's a more straight forward way of doing this sadly
+    login_page = client.get('/login')
+    m = re.search(r'<input id="csrf_token" name="csrf_token" type="hidden" value="([^"]+)">',
+                  login_page.data.decode('utf-8'))
+    csrf = m[1]
 
-  return csrf
+    return csrf
+
 
 def login(client, email, password):
-  """Log in a user and set a cookie on the client"""
-  csrf = csrf_token(client)
+    """Log in a user and set a cookie on the client"""
+    csrf = csrf_token(client)
 
-  response = client.post('/login', data=dict(
-      email=email,
-      password=password,
-      csrf_token=csrf
-  ), follow_redirects=True)
+    response = client.post('/login', data=dict(
+        email=email,
+        password=password,
+        csrf_token=csrf
+    ), follow_redirects=True)
 
-  # if(response.status_code != 302):
-  #   raise Exception('Did not log in: {0}'.format(response.status))
+    # if(response.status_code != 302):
+    #   raise Exception('Did not log in: {0}'.format(response.status))
+
 
 def login_admin(client):
-  """Log in the admin user created by the client fixture"""
-  login(client, 'admin@example.com', 'pass')
+    """Log in the admin user created by the client fixture"""
+    login(client, 'admin@example.com', 'pass')
 
 
 def logout(client):
-  """Log out the current user"""
-  return client.get('/logout', follow_redirects=True)
+    """Log out the current user"""
+    return client.get('/logout', follow_redirects=True)
+
 
 # Fixtures are created with the pytest.fixture decorator
 # They are called by adding an argument to the test method with
@@ -49,121 +54,127 @@ def logout(client):
 
 @pytest.fixture
 def client():
-  """Create a client to test requests to the app"""
-  app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
-  app.testing = True
+    """Create a client to test requests to the app"""
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.testing = True
 
-  # Set up the app context
-  with app.app_context():
-    # Create database and admin user
-    db.create_all()
+    # Set up the app context
+    with app.app_context():
+        # Create database and admin user
+        db.create_all()
 
-    # Create test client and run the tests
-    yield app.test_client()
+        # Create test client and run the tests
+        yield app.test_client()
 
-  # Empty database for next test
-  db.drop_all()
+    # Empty database for next test
+    db.drop_all()
+
 
 @pytest.fixture
 def admin(client):
-  """Create an admin user"""
-  user = models.User(
-    name = 'Admin',
-    email = 'admin@example.com',
-    role = 'ADMIN'
-  )
-  user.setPassword('pass')
-  db.session.add(user)
-  db.session.commit()
-  return user
+    """Create an admin user"""
+    user = models.User(
+        name='Admin',
+        email='admin@example.com',
+        role='ADMIN'
+    )
+    user.setPassword('pass')
+    db.session.add(user)
+    db.session.commit()
+    return user
+
 
 def test_library(client):
-  response = client.get('/library', headers = {
-    'Accept-Type': 'application/json'
-  })
+    response = client.get('/library', headers={
+        'Accept-Type': 'application/json'
+    })
 
-  assert response.data == b'{"page":1,"q":null,"scans":[],"showMine":false,"tags":{"taxonomy":[]},"total_pages":0}\n'
+    assert response.data == b'{"page":1,"q":null,"scans":[],"showMine":false,"tags":{"taxonomy":[]},"total_pages":0}\n'
+
 
 def test_manage_uploads(client, admin):
-  login_admin(client)
+    login_admin(client)
 
-  response = client.get('/library/manage-uploads/', headers = {
-    'Accept-Type': 'application/json'
-  })
+    response = client.get('/library/manage-uploads/', headers={
+        'Accept-Type': 'application/json'
+    })
 
-  data = json.loads(response.data)
+    data = json.loads(response.data)
 
-  assert data['page'] == 1
-  assert data['q'] == None
-  assert data['scans'] == []
-  assert data['total_pages'] == 0
+    assert data['page'] == 1
+    assert data['q'] == None
+    assert data['scans'] == []
+    assert data['total_pages'] == 0
+
 
 def test_stl_upload(client, tmpdir, admin):
-  """Test for uploading a file and making sure it gets zipped"""
-  login_admin(client)
+    """Test for uploading a file and making sure it gets zipped"""
+    login_admin(client)
 
-  app.config['UPLOAD_DIRECTORY'] = tmpdir
-  app.config['MODEL_DIRECTORY'] = tmpdir
+    app.config['UPLOAD_DIRECTORY'] = tmpdir
+    app.config['MODEL_DIRECTORY'] = tmpdir
 
-  import io, time
-  upload_file = (io.BytesIO(b'random data'), 'test_file.stl')
-  data = {'file': upload_file, 'csrf_token': csrf_token(client) }
-  response = client.post(
-      '/scans/create?noredirect=1',
-      data=data,
-      content_type='multipart/form-data',
-      headers = {
-        'Accept': 'application/json'
-      }
-  )
+    import io, time
+    upload_file = (io.BytesIO(b'random data'), 'test_file.stl')
+    data = {'file': upload_file, 'csrf_token': csrf_token(client)}
+    response = client.post(
+        '/scans/create?noredirect=1',
+        data=data,
+        content_type='multipart/form-data',
+        headers={
+            'Accept': 'application/json'
+        }
+    )
 
-  zip_file = '/'.join((time.strftime("%Y/%m/%d"), upload_file[1] + '.zip'))
-  expected_file = '/models/' + zip_file
-  expected_location = tmpdir.join(zip_file)
+    zip_file = '/'.join((time.strftime('%Y/%m/%d'), upload_file[1] + '.zip'))
+    expected_file = '/models/' + zip_file
+    expected_location = tmpdir.join(zip_file)
 
-  from os import path
+    from os import path
 
-  assert json.loads(response.data)['scan']['source'] == expected_file
-  assert path.exists(expected_location)
+    assert json.loads(response.data)['scan']['source'] == expected_file
+    assert path.exists(expected_location)
+
 
 def test_zip_upload(client, tmpdir, admin):
-  """Test for uploading a zip file"""
-  login_admin(client)
+    """Test for uploading a zip file"""
+    login_admin(client)
 
-  app.config['UPLOAD_DIRECTORY'] = tmpdir
-  app.config['MODEL_DIRECTORY'] = tmpdir
+    app.config['UPLOAD_DIRECTORY'] = tmpdir
+    app.config['MODEL_DIRECTORY'] = tmpdir
 
-  import io, time
-  from pathlib import Path
+    import io, time
+    from pathlib import Path
 
-  horse = io.BytesIO(Path(__file__).parent.parent.parent.joinpath('fixtures/Horse.zip').read_bytes())
-  upload_file = (horse, 'test_file.zip')
-  data = {'file': upload_file, 'csrf_token': csrf_token(client) }
-  response = client.post(
-      '/scans/create?noredirect=1',
-      data=data,
-      content_type='multipart/form-data',
-      headers = {
-        'Accept': 'application/json'
-      }
-  )
+    horse = io.BytesIO(Path(__file__).parent.parent.parent.joinpath('fixtures/Horse.zip').read_bytes())
+    upload_file = (horse, 'test_file.zip')
+    data = {'file': upload_file, 'csrf_token': csrf_token(client)}
+    response = client.post(
+        '/scans/create?noredirect=1',
+        data=data,
+        content_type='multipart/form-data',
+        headers={
+            'Accept': 'application/json'
+        }
+    )
 
-  zip_file = '/'.join((time.strftime("%Y/%m/%d"), upload_file[1]))
-  expected_file = '/models/' + zip_file
-  expected_location = tmpdir.join(zip_file)
+    zip_file = '/'.join((time.strftime('%Y/%m/%d'), upload_file[1]))
+    expected_file = '/models/' + zip_file
+    expected_location = tmpdir.join(zip_file)
 
-  from os import path
+    from os import path
 
-  assert json.loads(response.data)['scan']['source'] == expected_file
-  assert path.exists(expected_location)
+    assert json.loads(response.data)['scan']['source'] == expected_file
+    assert path.exists(expected_location)
 
-  assert models.Queue.query.order_by('created').first() != None
+    assert models.Queue.query.order_by('created').first() != None
+
 
 def test_upload_file_chunk(client, admin):
-  login_admin(client)
+    login_admin(client)
 
-  response = client.post('/files/')
-  assert response.status_code == 201
+    response = client.post('/files/')
+    assert response.status_code == 201
 
-  response = client.patch(response.location, data=u'some data')
-  assert response.status_code == 200
+    response = client.patch(response.location, data=u'some data')
+    assert response.status_code == 200

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -102,7 +102,7 @@ def test_manage_uploads(client, admin):
     data = json.loads(response.data)
 
     assert data['page'] == 1
-    assert data['q'] == None
+    assert data['q'] is None
     assert data['scans'] == []
     assert data['total_pages'] == 0
 
@@ -167,7 +167,7 @@ def test_zip_upload(client, tmpdir, admin):
     assert json.loads(response.data)['scan']['source'] == expected_file
     assert path.exists(expected_location)
 
-    assert models.Queue.query.order_by('created').first() != None
+    assert models.Queue.query.order_by('created').first() is not None
 
 
 def test_upload_file_chunk(client, admin):

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -80,7 +80,7 @@ def admin(client):
         email='admin@example.com',
         role='ADMIN'
     )
-    user.setPassword('pass')
+    user.set_password('pass')
     db.session.add(user)
     db.session.commit()
     return user

--- a/config.py
+++ b/config.py
@@ -1,5 +1,6 @@
 import os
-from dotenv import load_dotenv, find_dotenv
+
+from dotenv import load_dotenv
 
 basedir = os.path.abspath(os.path.dirname(__file__))
 # Parent directory takes precedence, which makes things
@@ -7,10 +8,11 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 load_dotenv(os.path.join(basedir, '../.env'))
 load_dotenv(os.path.join(basedir, '.env'))
 
+
 class Config(object):
     SECRET_KEY = os.environ.get('SECRET_KEY') or 'G}<Ci&XWqSqA/mF7ZCWI7JJ.:QuuZF'
-    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or \
-        'sqlite:///' + os.path.join(basedir, 'app.db')
+    SQLALCHEMY_DATABASE_URI = (os.environ.get('DATABASE_URL') or
+                               'sqlite:///' + os.path.join(basedir, 'app.db'))
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     RENDER_AS_BATCH = not os.environ.get('DATABASE_URL')
     MAIL_DEFAULT_SENDER = os.environ.get('MAIL_DEFAULT_SENDER') or 'no-reply@phenome10k.org'

--- a/gbif.py
+++ b/gbif.py
@@ -1,21 +1,23 @@
-from app import app, db
-from app.models import Taxonomy, Scan
+from app import db
 from app.gbif import pull_tags
+from app.models import Taxonomy, Scan
+
 
 def update_tags():
-  """ Updates taxonomy tags from gbif backbone and deletes unused ones """
-  print('Updating tags:')
-  for scan in Scan.query.filter(Scan.gbif_id).all():
-    tags = [
-      db.session.merge(tag) for tag in pull_tags(scan.gbif_id)
-    ]
-    scan.taxonomy = tags
-    print(' - ', scan.scientific_name)
+    """ Updates taxonomy tags from gbif backbone and deletes unused ones """
+    print('Updating tags:')
+    for scan in Scan.query.filter(Scan.gbif_id).all():
+        tags = [
+            db.session.merge(tag) for tag in pull_tags(scan.gbif_id)
+        ]
+        scan.taxonomy = tags
+        print(' - ', scan.scientific_name)
 
-  print('Deleting tags:')
-  for tax in Taxonomy.query.filter(db.not_(Taxonomy.scans.any())):
-    print(' - ', tax.name)
-    db.session.delete(tax)
-  db.session.commit()
+    print('Deleting tags:')
+    for tax in Taxonomy.query.filter(db.not_(Taxonomy.scans.any())):
+        print(' - ', tax.name)
+        db.session.delete(tax)
+    db.session.commit()
+
 
 update_tags()


### PR DESCRIPTION
Should not make any functional difference (other than perhaps avoiding a few bugs).
Reformatting Python files to conform to [PEP8](https://www.python.org/dev/peps/pep-0008) (except E501 - max line length is set to 120 instead of 79 because 79 is _so short_), plus a few other common practices. A quick summary:

- more blank lines added between methods
- standardised indentation (4 spaces, though happy to use tabs if preferred; this just fixes the mix of 4/2/n spaces)
- renamed variables and methods in camelCase to snake_case
- equality checking with `None` uses `is` instead of `==`
- renaming things with the same names as builtin modules/objects (`zip` and `id`)
- renaming things to avoid conflicts and/or confusion (e.g. `scan()` the method vs `scan` the arg)
- removing unnecessary imports
- local imports now all use absolute paths (except one place in `__init__.py` which probably needs to be sorted later)
- various other small formatting "fixes"