### PR TITLE
Add phpass to security config

### DIFF
--- a/api/phenome10k/config.py
+++ b/api/phenome10k/config.py
@@ -32,8 +32,9 @@ class Config(object):
     CELERY_BROKER_URL = os.environ.get('CELERY_BROKER_URL', 'amqp://guest:guest@localhost:5672')
     CELERY_RESULT_BACKEND = os.environ.get('CELERY_RESULTS_BACKEND', 'redis://localhost:6379/0')
     SECURITY_PASSWORD_HASH = 'argon2'
-    SECURITY_PASSWORD_SCHEMES = ['argon2']
-    SECURITY_PASSWORD_SINGLE_HASH = ['argon2']
+    SECURITY_PASSWORD_SCHEMES = ['argon2', 'phpass']
+    SECURITY_PASSWORD_SINGLE_HASH = ['argon2', 'phpass']
+    SECURITY_PASSWORD_SALT = os.environ.get('SECURITY_PASSWORD_SALT', 'c27Lq82!b!a7yRC9ssPn')
     SECURITY_REGISTERABLE = True
     SECURITY_RECOVERABLE = True
     SECURITY_CHANGEABLE = True


### PR DESCRIPTION
Addition of flask-security-too with only argon2 in the config meant that older phpass passwords were not accepted and couldn't even get to the point of being upgraded in the user model.