### PR TITLE
Thumbnails bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ coverage
 web/scss/.sass-cache/
 
 api/thumbnails/
+api/logs/
 
 build/
 

--- a/api/phenome10k/routes/files.py
+++ b/api/phenome10k/routes/files.py
@@ -106,7 +106,7 @@ def send_uploads(path):
         except FileExistsError:
             pass
 
-        height = im.height * width / im.width
+        height = im.height * width // im.width
         im.thumbnail((width, height))
         byte_io = io.BytesIO()
         im.save(byte_io, format='PNG')

--- a/api/phenome10k/routes/files.py
+++ b/api/phenome10k/routes/files.py
@@ -107,7 +107,11 @@ def send_uploads(path):
             pass
 
         height = im.height * width // im.width
-        im.thumbnail((width, height))
+        try:
+            im.thumbnail((width, height))
+        except OSError:
+            # if this didn't work, the image is broken
+            raise NotFound()
         byte_io = io.BytesIO()
         im.save(byte_io, format='PNG')
         im.save(thumbnail_file, format='PNG')

--- a/api/phenome10k/routes/files.py
+++ b/api/phenome10k/routes/files.py
@@ -6,8 +6,8 @@ from PIL import Image
 from flask import Blueprint, redirect, url_for, send_file
 from flask import Response, current_app, send_from_directory
 from flask import request
-from flask.helpers import safe_join
 from werkzeug.exceptions import NotFound, BadRequest
+from werkzeug.utils import safe_join
 
 from ._decorators import login_required, requires_contributor
 from ._utils import ensure_editable

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   data:
     image: mariadb:jammy


### PR DESCRIPTION
Fixes a couple of small issues with the `/uploads/` endpoint:
- height is now an int
- PIL was throwing an error when it tried to load a broken image in `im.thumbnail` (presumably this is the first place it properly tried to load it); this is now caught and returned as `NotFound`
- `safe_join` is now imported from werkzeug instead of flask

Also, nothing to do with thumbnails:
- docker compose version specifier removed (it's been deprecated)
- ignore dev logs