### PR TITLE
Performance fixes

### DIFF
--- a/ansible/group_vars/all/main.yml
+++ b/ansible/group_vars/all/main.yml
@@ -77,6 +77,7 @@ flower_broker_api: http://{{ p10k_db_user }}:{{ p10k_db_password|urlencode() }}@
   rabbitmq_host }}:15672/api/
 
 # p10k: flask
+cache_redis_url: redis://{{ redis_host }}:6379/1
 flask_secret_key: G}<Ci&XWqSqA/mF7ZCWI7JJ.:QuuZF
 gunicorn_binary: '{{ venv_bin }}/gunicorn'
 gunicorn_port: 8000

--- a/ansible/roles/phenome-10k/templates/.env.j2
+++ b/ansible/roles/phenome-10k/templates/.env.j2
@@ -16,3 +16,4 @@ HCAPTCHA_SITE_KEY={{ hcaptcha_site_key }}
 HCAPTCHA_SECRET_KEY={{ hcaptcha_secret_key }}
 MAIL_SERVER={{ mail_host }}
 SECURITY_PASSWORD_SALT={{ password_salt }}
+CACHE_REDIS_URL={{ cache_redis_url }}

--- a/ansible/roles/phenome-10k/templates/gunicorn.service.j2
+++ b/ansible/roles/phenome-10k/templates/gunicorn.service.j2
@@ -3,7 +3,7 @@ Description=phenome10k service
 
 [Service]
 Type=simple
-ExecStart={{ gunicorn_binary }} --error-logfile /var/log/phenome10k/error.log --access-logfile /var/log/phenome10k/access.log -b 0.0.0.0:{{ gunicorn_port }} -w 4 --threads 8 --timeout 120 api.wsgi:app
+ExecStart={{ gunicorn_binary }} --error-logfile /var/log/phenome10k/error.log --access-logfile /var/log/phenome10k/access.log -b 0.0.0.0:{{ gunicorn_port }} -w 9 --timeout 120 api.wsgi:app
 Restart=on-abort
 WorkingDirectory={{ p10k_src_dir }}
 User={{ p10k_linux_user }}

--- a/api/phenome10k/__init__.py
+++ b/api/phenome10k/__init__.py
@@ -13,6 +13,7 @@ from phenome10k.extensions import (
     ma,
     spec,
     captcha,
+    cache,
 )
 from phenome10k.forms import P10KLoginForm, P10KRegisterForm
 from phenome10k.models import user_datastore
@@ -63,6 +64,14 @@ def init(return_celery=False):
     scan_store.init_app(db)
     upload_store.init_app(app)
     ma.init_app(app)
+    cache.init_app(
+        app,
+        config={
+            'CACHE_TYPE': 'RedisCache',
+            'CACHE_KEY_PREFIX': 'p10k_cache_',
+            'CACHE_REDIS_URL': Config.CACHE_REDIS_URL,
+        },
+    )
     config_celery(app)
 
     from phenome10k.routes import init_routes

--- a/api/phenome10k/cli.py
+++ b/api/phenome10k/cli.py
@@ -77,5 +77,19 @@ def update_gbif_tags():
     click.echo('Deleted.' if is_deleted else 'Did not exist or could not be deleted.')
 
 
+@cli.command()
+@click.argument('keys', nargs=-1)
+def clear_cache(keys):
+    """
+    Clears items from the flask cache (not the celery cache).
+    """
+    if keys:
+        cache.delete_many(*keys)
+        click.echo(f'Removed {len(keys)} keys from cache.')
+    else:
+        cache.clear()
+        click.echo('Cleared whole cache.')
+
+
 if __name__ == '__main__':
     cli()

--- a/api/phenome10k/cli.py
+++ b/api/phenome10k/cli.py
@@ -2,7 +2,7 @@ import click
 from flask.cli import FlaskGroup
 from phenome10k import create_app
 from phenome10k.data.gbif import pull_tags
-from phenome10k.extensions import db, security
+from phenome10k.extensions import db, security, cache
 from phenome10k.models import User, Scan, Taxonomy
 from datetime import datetime as dt
 from sqlalchemy import select
@@ -71,6 +71,10 @@ def update_gbif_tags():
         click.echo(' - ' + tax.name)
         db.session.delete(tax)
     db.session.commit()
+
+    click.echo('Clearing taxonomy tree cache:')
+    is_deleted = cache.delete('taxonomy_tree')
+    click.echo('Deleted.' if is_deleted else 'Did not exist or could not be deleted.')
 
 
 if __name__ == '__main__':

--- a/api/phenome10k/config.py
+++ b/api/phenome10k/config.py
@@ -56,6 +56,7 @@ class Config(object):
     HCAPTCHA_ENABLED = not os.environ.get('FLASK_DEBUG', False)
     HCAPTCHA_SITE_KEY = os.environ.get('HCAPTCHA_SITE_KEY')
     HCAPTCHA_SECRET_KEY = os.environ.get('HCAPTCHA_SECRET_KEY')
+    CACHE_REDIS_URL = os.environ.get('CACHE_REDIS_URL', 'redis://localhost:6379/0')
 
 
 def get_celery_config():

--- a/api/phenome10k/extensions.py
+++ b/api/phenome10k/extensions.py
@@ -4,6 +4,7 @@ from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_marshmallow import Marshmallow
 from flask_hcaptcha import hCaptcha
+from flask_caching import Cache
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
 from apispec_webframeworks.flask import FlaskPlugin
@@ -22,6 +23,7 @@ spec = APISpec(
     openapi_version='3.1.0',
     plugins=[FlaskPlugin(), MarshmallowPlugin()],
 )
+cache = Cache()
 
 scan_store = ScanStore()
 upload_store = TmpUploadStore()

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -8,6 +8,7 @@ click
 cryptography==39.0.1
 email-validator==1.2.1
 Flask==2.0.3
+flask-caching==2.3.0
 flask-hcaptcha==0.6.0
 Flask-Mail==0.9.1
 Flask-Migrate==3.1.0

--- a/docker/.env
+++ b/docker/.env
@@ -1,3 +1,4 @@
 DATABASE_URL=mysql+pymysql://phenome10k:Aei0_rr2rr2r2r2r@data:3306/phenome10k
 CELERY_BROKER_URL=amqp://phenome10k:password@app-rabbitmq:5672
 CELERY_RESULTS_BACKEND=redis://app-redis:6379
+CACHE_REDIS_URL=redis://app-redis:6379/1


### PR DESCRIPTION
- update gunicorn config to use more workers than threads
- add cache (on redis, using flask-caching)
- cache very slow taxonomy tree function indefinitely (is removed when `update-gbif-tags` cli command is run, or can be explicitly removed with new `clear-cache` command)