### PR TITLE
Swap from gunicorn to uwsgi

### DIFF
--- a/ansible/group_vars/all/main.yml
+++ b/ansible/group_vars/all/main.yml
@@ -79,8 +79,9 @@ flower_broker_api: http://{{ p10k_db_user }}:{{ p10k_db_password|urlencode() }}@
 # p10k: flask
 cache_redis_url: redis://{{ redis_host }}:6379/1
 flask_secret_key: G}<Ci&XWqSqA/mF7ZCWI7JJ.:QuuZF
-gunicorn_binary: '{{ venv_bin }}/gunicorn'
-gunicorn_port: 8000
+uwsgi_binary: "{{ venv_bin }}/uwsgi"
+uwsgi_ini: "{{ p10k_home }}/uswgi.ini"
+uwsgi_port: 8000
 p10k_admin_email: a.goswami@nhm.ac.uk
 p10k_admin_password: pass
 password_salt: 7mrUh6kF*&PEh2gUTmHc

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -25,7 +25,7 @@
     - monit/monit
   vars:
     monit_services:
-      - gunicorn
+      - uwsgi
       - systems
       - 50gb-root-partition
 

--- a/ansible/roles/monit/monit/defaults/main.yml
+++ b/ansible/roles/monit/monit/defaults/main.yml
@@ -14,12 +14,12 @@ monit_eventqueue:
 # Active - try and restart services
 monit_monitoring_mode: active
 monit_services_conf:
-  gunicorn:
+  uwsgi:
     check_type: process
-    check_id: gunicorn
+    check_id: uwsgi
     id_type: matching
-    start: /bin/systemctl restart gunicorn
-    stop: /bin/systemctl stop gunicorn
+    start: /bin/systemctl restart uwsgi
+    stop: /bin/systemctl stop uwsgi
     group: web
     tests:
       - condition: cpu > 60% for 20 cycles

--- a/ansible/roles/nginx/templates/phenome10k.org.conf.j2
+++ b/ansible/roles/nginx/templates/phenome10k.org.conf.j2
@@ -1,5 +1,5 @@
 upstream phenome10k {
-{% for server in app_servers %}  server {{ server }}:{{ gunicorn_port }};{% endfor %}
+{% for server in app_servers %}  server {{ server }}:{{ uwsgi_port }};{% endfor %}
 }
 
 server {

--- a/ansible/roles/nginx/templates/phenome10k.org.ssl.conf.j2
+++ b/ansible/roles/nginx/templates/phenome10k.org.ssl.conf.j2
@@ -1,5 +1,5 @@
 upstream phenome10k {
-{% for server in app_servers %}  server {{ server }}:{{ gunicorn_port }};{% endfor %}
+{% for server in app_servers %}  server {{ server }}:{{ uwsgi_port }};{% endfor %}
 }
 
 server {

--- a/ansible/roles/phenome-10k/handlers/main.yml
+++ b/ansible/roles/phenome-10k/handlers/main.yml
@@ -17,9 +17,9 @@
   become: true
   become_user: phenome10k
 
-- name: restart gunicorn
+- name: restart uwsgi
   service:
-    name: gunicorn
+    name: uwsgi
     state: restarted
   become: true
 

--- a/ansible/roles/phenome-10k/tasks/app-flask.yml
+++ b/ansible/roles/phenome-10k/tasks/app-flask.yml
@@ -55,17 +55,26 @@
   become_user: phenome10k
   run_once: true
 
-- name: Create the gunicorn service
+- name: Copy uwsgi.ini config
   template:
-    src: gunicorn.service.j2
-    dest: /etc/systemd/system/gunicorn.service
+    src: uwsgi.ini.j2
+    dest: '{{ uwsgi_ini }}'
+  become: true
+  become_user: phenome10k
+  notify:
+    - restart uwsgi
+
+- name: Create the uwsgi service
+  template:
+    src: uwsgi.service.j2
+    dest: /etc/systemd/system/uwsgi.service
   become: true
   notify:
-    - restart gunicorn
+    - restart uwsgi
 
-- name: Enable gunicorn service
+- name: Enable uwsgi service
   systemd:
-    name: gunicorn.service
+    name: uwsgi.service
     state: started
     enabled: y
   become: true

--- a/ansible/roles/phenome-10k/tasks/main.yml
+++ b/ansible/roles/phenome-10k/tasks/main.yml
@@ -17,7 +17,7 @@
   when: not skip_git_checkout
   notify:
     - rebuild front end
-    - restart gunicorn
+    - restart uwsgi
     - restart node
   tags:
     - flask
@@ -55,7 +55,7 @@
   become: true
   become_user: phenome10k
   notify:
-    - restart gunicorn
+    - restart uwsgi
 
 - name: Create log directory
   file:

--- a/ansible/roles/phenome-10k/templates/uwsgi.ini.j2
+++ b/ansible/roles/phenome-10k/templates/uwsgi.ini.j2
@@ -1,0 +1,14 @@
+[uwsgi]
+http = 0.0.0.0:{{ uwsgi_port }}
+wsgi-file = api/wsgi.py
+callable = app
+wsgi-disable-file-wrapper = true
+master = true
+processes = 3
+threads = 3
+buffer-size = 65535
+stats = 127.0.0.1:9191
+log-5xx = true
+
+req-logger = file:/var/log/phenome10k/u_access.log
+logger = file:/var/log/phenome10k/u_error.log

--- a/ansible/roles/phenome-10k/templates/uwsgi.service.j2
+++ b/ansible/roles/phenome-10k/templates/uwsgi.service.j2
@@ -3,7 +3,7 @@ Description=phenome10k service
 
 [Service]
 Type=simple
-ExecStart={{ gunicorn_binary }} --error-logfile /var/log/phenome10k/error.log --access-logfile /var/log/phenome10k/access.log -b 0.0.0.0:{{ gunicorn_port }} -w 9 --timeout 120 api.wsgi:app
+ExecStart={{ uwsgi_binary }} --ini {{ uwsgi_ini }}
 Restart=on-abort
 WorkingDirectory={{ p10k_src_dir }}
 User={{ p10k_linux_user }}

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -17,7 +17,7 @@ Flask-SQLAlchemy==2.5.1
 Flask-WTF==1.0.1
 Flask-Marshmallow==0.14.0
 flower==1.2.0
-gunicorn==20.1.0
+pyuwsgi==2.0.26
 importlib-metadata==4.11.3
 marshmallow-sqlalchemy==0.28.0
 numpy==1.22.3


### PR DESCRIPTION
We've been having uptime issues with the phenome10k production site and it's unclear exactly what's going on. Changing gunicorn for uwsgi seems to have helped in testing so we're making the change for good.

Current theory is that something we're doing (or a lib we're using) is doing something with multiprocessing and causing gunicorn to hang. This results in the gunicorn instance not responding to any requests until it's rebooted. The master gunicorn process doesn't seem to notice that the workers are unresponsive (maybe it's actually the master that is kaput?) and so it just all hangs up. Example maybe related gunicorn issue: https://github.com/benoitc/gunicorn/issues/1923.

Switching to uWSGI seems to work better at least for now. 