### PR TITLE
Disable strict_slashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ dist/
 api/phenome10k.egg-info/
 
 docker/local.env
+
+logs/

--- a/api/phenome10k/config.py
+++ b/api/phenome10k/config.py
@@ -24,7 +24,7 @@ class Config(object):
     MAIL_PORT = os.environ.get('MAIL_PORT', 25)
     MAIL_USERNAME = os.environ.get('MAIL_USERNAME')
     MAIL_PASSWORD = os.environ.get('MAIL_PASSWORD')
-    ADMIN_EMAIL = os.environ.get('ADMIN_EMAIL') or 'alycejenni@gmail.com'
+    ADMIN_EMAIL = os.environ.get('ADMIN_EMAIL') or 'phenome10k@nhm.ac.uk'
     LOG_FILE = os.environ.get('LOG_FILE') or 'logs/phenome10k.log'
     LOG_LEVEL = os.environ.get('LOG_LEVEL', 'WARNING')
     SERVER_NAME = os.environ.get('SERVER_NAME') or None

--- a/api/phenome10k/routes/__init__.py
+++ b/api/phenome10k/routes/__init__.py
@@ -15,6 +15,7 @@ def init_routes(app):
         query.bp,
     ]
 
+    app.url_map.strict_slashes = False
     app.url_map.converters['scan'] = ScanConverter
     app.url_map.converters['publication'] = PublicationConverter
     app.url_map.converters['file'] = FileConverter

--- a/api/phenome10k/routes/publications.py
+++ b/api/phenome10k/routes/publications.py
@@ -123,7 +123,7 @@ def manage(page=1):
     return render_vue(data, title='Manage Publications')
 
 
-@bp.route('/<publication:pub_object>/')
+@bp.route('/<publication:pub_object>')
 def view(pub_object):
     if not pub_object.published and not (
         current_user.is_authenticated and current_user.can_edit(pub_object)

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.8"
 license = { text = "GPL-3.0-or-later" }
 authors = [
     { name = "Paul Kiddle" },
-    { name = "Ginger Butcher", email = "phenome10k@nhm.ac.uk" }
+    { name = "Ginger Burns", email = "phenome10k@nhm.ac.uk" }
 ]
 keywords = []
 classifiers = [

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -11,11 +11,11 @@ Flask==2.0.3
 flask-caching==2.3.0
 flask-hcaptcha==0.6.0
 Flask-Mail==0.9.1
+Flask-Marshmallow==0.14.0
 Flask-Migrate==3.1.0
 flask-security-too==5.0.1
 Flask-SQLAlchemy==2.5.1
 Flask-WTF==1.0.1
-Flask-Marshmallow==0.14.0
 flower==1.2.0
 gunicorn==20.1.0
 importlib-metadata==4.11.3


### PR DESCRIPTION
The main issue: `strict_slashes` is `True` for every route by default, which means that someone navigating to `/scan-name` gets redirected to `/scan-name/` (since the route definition contains a trailing slash). This is a 308 redirect. In firefox, the redirected request does not get the cookies for the original request, so no session information is available.

Setting `strict_slashes` to `False` by default means that trailing slashes won't matter, so the requests won't get redirected - they'll just load the page directly.

There's also a few other minor fixes in here for things I found while trying to debug this.

Closes: #206