### PR TITLE
API fix

### DIFF
--- a/api/phenome10k/routes/_utils.py
+++ b/api/phenome10k/routes/_utils.py
@@ -161,6 +161,8 @@ class Query(object):
                 for c in self._columns.values():
                     try:
                         v = c.type.python_type(r.q)
+                        if type(v) is bool:
+                            continue
                         or_filters.append(c == v)
                     except:
                         continue


### PR DESCRIPTION
Fixes a bug with the API where searching using a string in a table with a boolean column would return all rows where the boolean = true.

e.g. `/api/v1/scan/search?q=Panthera` would return all scans where `published` was true.

Closes #207 